### PR TITLE
setting @mix_env at compile time

### DIFF
--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -6,14 +6,14 @@ defmodule Honeybadger do
 
   @moduledoc """
     This module contains the notify macro and context function you can use in
-    your applications. 
-    
+    your applications.
+
     ### Configuring
     By default the HONEYBADGER_API_KEY environment variable is used to find
     your API key for Honeybadger. You can also manually set your API key by
     configuring the :honeybadger application. You can see the default
     configuration in the default_config/0 private function at the bottom of
-    this file. 
+    this file.
 
         config :honeybadger,
           api_key: "mysupersecretkey",
@@ -40,7 +40,7 @@ defmodule Honeybadger do
     Honeybadger API when/if an exception occurs in that process. Do keep in
     mind the process dictionary is used for retrieving this context so try not
     to put large data structures in the context.
-        
+
         Honeybadger.context(user_id: 1, account: "My Favorite Customer")
         Honeybadger.context(%{user_id: 2, account: "That Needy Customer")
 
@@ -87,7 +87,7 @@ defmodule Honeybadger do
     Honeybadger client's dependencies. You'll likely never need to call this
     function yourself.
   """
-  def start(_type, _opts) do 
+  def start(_type, _opts) do
     app_config = Application.get_all_env(:honeybadger)
     config = Keyword.merge(default_config, app_config)
 
@@ -114,10 +114,11 @@ defmodule Honeybadger do
     macro_notify(exception, context, stacktrace)
   end
 
+  @mix_env Mix.env
   defp macro_notify(exception, context, stacktrace) do
     exclude_envs = Application.get_env(:honeybadger, :exclude_envs, [:dev, :test])
-    
-    case Mix.env in exclude_envs do
+
+    case @mix_env in exclude_envs do
       false ->
         quote do
           Honeybadger.do_notify(unquote(exception), unquote(context), unquote(stacktrace))

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -114,11 +114,10 @@ defmodule Honeybadger do
     macro_notify(exception, context, stacktrace)
   end
 
-  @mix_env Mix.env
   defp macro_notify(exception, context, stacktrace) do
     exclude_envs = Application.get_env(:honeybadger, :exclude_envs, [:dev, :test])
 
-    case @mix_env in exclude_envs do
+    case Mix.env in exclude_envs do
       false ->
         quote do
           Honeybadger.do_notify(unquote(exception), unquote(context), unquote(stacktrace))

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -33,9 +33,9 @@ defmodule Honeybadger.Notice do
       version: unquote(version)}
   end
 
-
+  @mix_env Mix.env
   defp server do
-    %{environment_name: Mix.env,
+    %{environment_name: @mix_env,
       hostname: hostname,
       project_root: project_root}
   end

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -33,9 +33,9 @@ defmodule Honeybadger.Notice do
       version: unquote(version)}
   end
 
-  @mix_env Mix.env
+
   defp server do
-    %{environment_name: @mix_env,
+    %{environment_name: Mix.env,
       hostname: hostname,
       project_root: project_root}
   end

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -18,9 +18,9 @@ defmodule Honeybadger.Notice do
               |> Dict.get(:plug_env, %{})
               |> Dict.merge(%{context: context})
 
-    %__MODULE__{error: error, 
-                request: request, 
-                notifier: notifier, 
+    %__MODULE__{error: error,
+                request: request,
+                notifier: notifier,
                 server: server}
   end
 
@@ -33,8 +33,9 @@ defmodule Honeybadger.Notice do
       version: unquote(version)}
   end
 
+  @mix_env Mix.env
   defp server do
-    %{environment_name: Mix.env,
+    %{environment_name: @mix_env,
       hostname: hostname,
       project_root: project_root}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,12 @@
 defmodule Honeybadger.Mixfile do
   use Mix.Project
-
+  @mix_env Mix.env
   def project do
     [app: :honeybadger,
      version: "0.1.2",
      elixir: "~> 1.0",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
+     build_embedded: @mix_env == :prod,
+     start_permanent: @mix_env == :prod,
      deps: deps,
      package: package,
      name: "Honeybadger",

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,11 @@
 defmodule Honeybadger.Mixfile do
   use Mix.Project
-  @mix_env Mix.env
   def project do
     [app: :honeybadger,
      version: "0.1.2",
      elixir: "~> 1.0",
-     build_embedded: @mix_env == :prod,
-     start_permanent: @mix_env == :prod,
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
      deps: deps,
      package: package,
      name: "Honeybadger",


### PR DESCRIPTION
setting @mix_env at compile time so its available in production without including Mix at runtime.
This was an issue that came forward using Exrm as deploy mechanism.