### PR TITLE
Only handle error messages that are lists

### DIFF
--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -16,12 +16,8 @@ defmodule Honeybadger.Logger do
     {:ok, state}
   end
 
-  def handle_event({level, _gl, _event}, state)
-  when level != :error_report do
-    {:ok, state}
-  end
-
-  def handle_event({error, _gl, {_pid, _type, [message | _]}}, state) do
+  def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state) 
+  when is_list(message) do
     try do
       dict = Dict.take(message, [:error_info, :dictionary])
       context = Dict.take(dict[:dictionary], [:honeybadger_context]) |> Enum.into(Map.new)
@@ -39,6 +35,10 @@ defmodule Honeybadger.Logger do
         Logger.warn(message)
     end
 
+    {:ok, state}
+  end
+
+  def handle_event({_level, _gl, _event}, state) do
     {:ok, state}
   end
 end


### PR DESCRIPTION
This addresses issue #10.

Some supervisor messages were making it through and the message types
were of tuple. This caused the code that looks into the message using
Dict to fail.

This change uses a guard to check that the message is a
list and matches specifically on an error type of `:error_report`. I've
also added a catch all message type after the main handle_event to
swallow all other messages.