### PR TITLE
Make environment name configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Here are all of the options you can pass in the keyword list:
 | hostname     | Hostname of the system your application is running on                     | :inet.gethostname |
 | origin       | URL for the Honeybadger API                                               | "https://api.honeybadger.io" |
 | project_root | Directory root for where your application is running                      | System.cwd |
+| environment_name | The name of the environment your app is running in.                   | Mix.env |
 
 ## Public Interface
 

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -117,7 +117,7 @@ defmodule Honeybadger do
   defp macro_notify(exception, context, stacktrace) do
     exclude_envs = Application.get_env(:honeybadger, :exclude_envs, [:dev, :test])
 
-    case Mix.env in exclude_envs do
+    case Application.get_env(:honeybadger, :environment_name) in exclude_envs do
       false ->
         quote do
           Task.start fn ->
@@ -161,6 +161,7 @@ defmodule Honeybadger do
       hostname: :inet.gethostname |> elem(1) |> List.to_string,
       origin: "https://api.honeybadger.io",
       project_root: System.cwd,
-      use_logger: true]
+      use_logger: true,
+      environment_name: nil]
   end
 end

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -34,9 +34,8 @@ defmodule Honeybadger.Notice do
       version: unquote(version)}
   end
 
-  @mix_env Mix.env
   defp server do
-    %{environment_name: @mix_env,
+    %{environment_name: environment_name,
       hostname: hostname,
       project_root: project_root}
   end
@@ -47,5 +46,9 @@ defmodule Honeybadger.Notice do
 
   defp project_root do
     Application.get_env(:honeybadger, :project_root)
+  end
+
+  defp environment_name do
+    Application.get_env(:honeybadger, :environment_name)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,7 @@ defmodule Honeybadger.Mixfile do
 
   def application do
     [applications: [:httpoison, :logger],
+     env: [environment_name: Mix.env],
      mod: {Honeybadger, []}]
   end
 

--- a/test/notice_test.exs
+++ b/test/notice_test.exs
@@ -34,6 +34,14 @@ defmodule Honeybadger.NoticeTest do
     assert System.cwd == server[:project_root]
   end
 
+  test "server information config", _ do
+    before = Application.get_env(:honeybadger, :environment_name)
+    Application.put_env(:honeybadger, :environment_name, "foo")
+    %Notice{server: server} = Notice.new(%RuntimeError{message: "Oops"}, %{}, [])
+    Application.put_env(:honeybadger, :environment_name, before)
+    assert "foo" == server[:environment_name]
+  end
+
   test "error information", %{notice: %Notice{error: error}} do
     assert "RuntimeError" == error[:class]
     assert "Oops"         == error[:message]


### PR DESCRIPTION
This also fixes the issue of depending on Mix.env at runtime. It may *not* fix the issue of the *correct* `MIX_ENV` being picked up. I just did a test with crywolf/phoenix and it *did* default my Honeybadger environment_name to `:prod` when I ran the phoenix server with `MIX_ENV=prod`, so maybe it's not an issue if we do it this way. I think the concern was that once the honeybadger package is compiled then the default `Mix.env` is hard-coded.