### PR TITLE
Send the entire process dictionary as context, let Notice pull out the context

### DIFF
--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -153,6 +153,7 @@ defmodule Honeybadger do
 
   def context(dict) do
     Process.put(@context, Dict.merge(context, dict))
+    context
   end
 
   defp default_config do

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -20,7 +20,8 @@ defmodule Honeybadger.Logger do
   when is_list(message) do
     try do
       error_info = message[:error_info]
-      context = message[:dictionary]
+      context = get_in(message, [:dictionary, :honeybadger_context])
+      context = %{context: context}
 
       case error_info do
         {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -19,9 +19,10 @@ defmodule Honeybadger.Logger do
   def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state) 
   when is_list(message) do
     try do
-      dict = Dict.take(message, [:error_info, :dictionary])
-      context = Dict.take(dict[:dictionary], [:honeybadger_context]) |> Enum.into(Map.new)
-      case Dict.get(dict, :error_info) do
+      error_info = message[:error_info]
+      context = message[:dictionary]
+
+      case error_info do
         {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
           Honeybadger.notify(exception, context, stacktrace)
         {_kind, exception, stacktrace} ->

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -6,18 +6,13 @@ defmodule Honeybadger.Notice do
   def new(exception, metadata \\ %{}, backtrace) do
     exception = Exception.normalize(:error, exception)
     exception_mod = exception.__struct__
-
     error = %{
       class: Utils.strip_elixir_prefix(exception_mod),
       message: exception_mod.message(exception),
       tags: Dict.get(metadata, :tags, []),
       backtrace: backtrace
     }
-
-    context = Dict.get(metadata, :honeybadger_context, %{}) |> Enum.into(Map.new)
-    request = metadata
-              |> Dict.get(:plug_env, %{})
-              |> Dict.merge(%{context: context})
+    request = Dict.take(metadata, [:plug_env, :context])
 
     %__MODULE__{error: error,
                 request: request,

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -21,7 +21,7 @@ defmodule Honeybadger.Plug do
 
       defp handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
         metadata = %{plug_env: build_plug_env(conn, __MODULE__), 
-                     honeybadger_context: Honeybadger.context()}
+                     context: Honeybadger.context()}
         Honeybadger.notify(exception, metadata, stack)
       end
     end

--- a/test/notice_test.exs
+++ b/test/notice_test.exs
@@ -11,7 +11,7 @@ defmodule Honeybadger.NoticeTest do
       action: :show,
       params: %{page: 1}
     }
-    metadata = %{plug_env: plug_env, tags: [:test], honeybadger_context: %{user_id: 1, account_id: 1}}
+    metadata = %{plug_env: plug_env, tags: [:test], context: %{user_id: 1, account_id: 1}}
     stack = [{Kernel, :+, [1], [file: 'lib/elixir/lib/kernel.ex', line: 321]}]
     backtrace = Backtrace.from_stacktrace(stack)
 
@@ -51,10 +51,12 @@ defmodule Honeybadger.NoticeTest do
 
   test "request information", %{notice: %Notice{request: request}} do
     assert %{
-      action: :show,
-      component: SomeApp.PageController,
-      params: %{page: 1},
-      url: "/pages/1"
+      plug_env: %{
+        action: :show,
+        component: SomeApp.PageController,
+        params: %{page: 1},
+        url: "/pages/1"
+      }
     } == Dict.drop(request, [:context])
 
     assert %{user_id: 1, account_id: 1} == request[:context]

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -42,16 +42,16 @@ defmodule Honeybadger.PlugTest do
     conn = conn(:get, "/bang")
     {_, remote_port} = conn.peer
     cgi_data = %{"CONTENT_LENGTH" => [],
-                  "ORIGINAL_FULLPATH" => "/bang",
-                  "PATH_INFO" => "bang",
-                  "QUERY_STRING" => "",
-                  "REMOTE_ADDR" => "127.0.0.1",
-                  "REMOTE_PORT" => remote_port,
-                  "REQUEST_METHOD" => "GET",
-                  "SCRIPT_NAME" => "",
-                  "SERVER_ADDR" => "127.0.0.1",
-                  "SERVER_NAME" => Application.get_env(:honeybadger, :hostname),
-                  "SERVER_PORT" => 80}
+                 "ORIGINAL_FULLPATH" => "/bang",
+                 "PATH_INFO" => "bang",
+                 "QUERY_STRING" => "",
+                 "REMOTE_ADDR" => "127.0.0.1",
+                 "REMOTE_PORT" => remote_port,
+                 "REQUEST_METHOD" => "GET",
+                 "SCRIPT_NAME" => "",
+                 "SERVER_ADDR" => "127.0.0.1",
+                 "SERVER_NAME" => Application.get_env(:honeybadger, :hostname),
+                 "SERVER_PORT" => 80}
 
     assert cgi_data == Honeybadger.Plug.build_cgi_data(conn)
   end


### PR DESCRIPTION
This fixes #19. The context wasn't getting sent because we were taking the `honeybadger_context` key out with our call to `Dict.take/2`. Instead we can just call notify with the entire process dictionary and Honeybadger.Notice does the right thing and only sends the value at `:honeybadger_context`.