### PR TITLE
Add poison to applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Honeybadger.Mixfile do
   end
 
   def application do
-    [applications: [:httpoison, :logger],
+    [applications: [:httpoison, :logger, :poison],
      env: [environment_name: Mix.env],
      mod: {Honeybadger, []}]
   end


### PR DESCRIPTION
I did some manual testing with using exrm as well as building the code normally and adding `poison` to `applications` does not have a negative affect. This fixes #26.