### PR TITLE
Send web app request stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: elixir
+elixir:
+  - 1.2.3
+  - 1.1.1
+otp_release:
+  - 18.3

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,6 @@
 use Mix.Config
 
-config :honeybadger, :environment_name, :test
+config :honeybadger,
+  environment_name: :test,
+  api_key: "abc123",
+  origin: "https://localhost:4000"

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -1,0 +1,46 @@
+defmodule Honeybadger.Client do
+  alias Poison, as: JSON
+
+  defstruct [:environment_name, :headers, :hostname, :origin]
+
+  @metrics_endpoint "/v1/metrics"
+  @notices_endpoint "/v1/notices"
+
+  def new do
+    origin = Application.get_env(:honeybadger, :origin)
+    api_key = Application.get_env(:honeybadger, :api_key)
+    env_name = Application.get_env(:honeybadger, :environment_name)
+    hostname = Application.get_env(:honeybadger, :hostname)
+    %__MODULE__{origin: origin, 
+                headers: headers(api_key),
+                environment_name: env_name,
+                hostname: hostname}
+  end
+
+  def send_metric(%__MODULE__{} = client, metric, http_mod \\ HTTPoison) do
+    body = JSON.encode!(%{
+      environment: client.environment_name,
+      hostname: client.hostname,
+      metrics: metric
+    })
+
+    http_mod.post(
+      client.origin <> @metrics_endpoint, body, client.headers
+    )
+  end
+
+  def send_notice(%__MODULE__{} = client, metric, http_mod \\ HTTPoison) do
+    body = JSON.encode!(metric)
+
+    http_mod.post(
+      client.origin <> @notices_endpoint, body, client.headers
+    )
+  end
+
+  defp headers(api_key) do
+    [{"Accept", "application/json"},
+     {"Content-Type", "application/json"},
+     {"X-API-Key", api_key}]
+  end
+
+end

--- a/lib/honeybadger/metric.ex
+++ b/lib/honeybadger/metric.ex
@@ -1,0 +1,31 @@
+defmodule Honeybadger.Metric do
+  alias Honeybadger.Metrics.Math
+
+  defstruct [:count, :max, :mean, :median, :min, :percentile_90, :stddev]
+
+  def new(responses) do
+    %__MODULE__{
+      count: Enum.count(responses),
+      max: Math.max(responses),
+      mean: Math.mean(responses),
+      median: Math.median(responses),
+      min: Math.min(responses),
+      percentile_90: Math.percentile(responses, 90),
+      stddev: Math.standard_deviation(responses),
+    }
+  end
+end
+
+defimpl Poison.Encoder, for: Honeybadger.Metric do
+
+  def encode(metric, _options) do
+    metric
+    |> Map.from_struct
+    |> Map.drop([:count])
+    |> Enum.reduce(["app.request.200 #{metric.count}"], fn({metric, value}, acc) ->
+         ["app.request.200:" <> "#{metric} #{value}" | acc]
+       end)
+    |> Poison.encode!
+  end
+
+end

--- a/lib/honeybadger/metrics/math.ex
+++ b/lib/honeybadger/metrics/math.ex
@@ -1,0 +1,65 @@
+defmodule Honeybadger.Metrics.Math do
+
+  def mean([]), do: 0
+  def mean(requests) do
+    total = Enum.sum(requests)
+    count = Enum.count(requests)
+    total / count
+  end
+
+  def median([]), do: 0
+  def median(requests) do
+    middle = Enum.count(requests) |> div(2)
+    requests 
+    |> Enum.sort 
+    |> Enum.at(middle)
+  end
+
+  def max([]), do: 0
+  def max(requests), do: Enum.max(requests)
+
+  def min([]), do: 0
+  def min(requests), do: Enum.min(requests)
+
+  def standard_deviation([]), do: 0
+  def standard_deviation(requests) do
+    variance(requests) 
+    |> :math.sqrt
+    |> Float.round(2)
+  end
+
+  def variance([]), do: 0
+  def variance(requests) do
+    squared_diff = Enum.reduce(requests, 0.0, fn(request, sum) ->
+      diff = request - mean(requests)
+      sum + (diff * diff)
+    end)
+    squared_diff / Enum.count(requests)
+  end
+
+  def percentile([]), do: 0
+
+  def percentile(requests, k) 
+  when is_integer(k)
+  and k >= 0 and k <= 100 do
+    percentile(requests, k * 0.01)
+  end
+
+  def percentile(requests, k) when is_float(k) do
+    ordered = Enum.sort(requests)
+    index = Enum.count(requests) * k
+
+    case whole_number?(index) do
+      true ->
+        index = round(index)
+        ordered
+        |> Enum.slice(index - 1, 2) 
+        |> mean
+      false ->
+        adjusted = Float.ceil(index) |> round
+        Enum.at(ordered, adjusted - 1)
+    end
+  end
+
+  defp whole_number?(num), do: round(num) == num
+end

--- a/lib/honeybadger/metrics/server.ex
+++ b/lib/honeybadger/metrics/server.ex
@@ -1,0 +1,58 @@
+defmodule Honeybadger.Metrics.Server do
+  use GenServer
+  alias Honeybadger.Metric
+  alias Honeybadger.Client
+
+  @moduledoc """
+    This GenServer receives metrics (the response time) from
+    the Honeybadger Plug. Every 60 seconds this GenServer will
+    message itself to flush the list of response times to the
+    Honeybadger metrics API.
+  """
+
+  @one_minute 60_000
+
+  def start_link(flush_interval \\ @one_minute, name \\ __MODULE__) do
+    GenServer.start_link(__MODULE__, flush_interval, name: name)
+  end
+
+  ## API
+
+  def timing(time) do
+    GenServer.cast(__MODULE__, {:add_timing, time})
+  end
+
+  ## GenServer Callbacks
+
+  def init(flush_interval) do
+    schedule_flush_message(flush_interval)
+    {:ok, %{timings: [], interval: flush_interval}}
+  end
+
+  def handle_cast({:add_timing, time}, state) do
+    {_, state} = Map.get_and_update(state, :timings, fn(timings) ->
+      {timings, [time | timings]}
+
+    end)
+    {:noreply, state}
+  end
+
+  def handle_info(:flush, %{timings: []} = state) do
+    schedule_flush_message(state[:interval])
+    {:noreply, state}
+  end
+
+  def handle_info(:flush, state) do
+    schedule_flush_message(state[:interval])
+    client = Client.new
+    metric = Metric.new(state[:timings])
+    Client.send_metric(client, metric, HTTPoison)
+    {:noreply, Map.put(state, :timings, [])}
+  end
+
+  ## Private API
+
+  defp schedule_flush_message(flush_interval) do
+    Process.send_after(self, :flush, flush_interval)
+  end
+end

--- a/lib/honeybadger/metrics/supervisor.ex
+++ b/lib/honeybadger/metrics/supervisor.ex
@@ -1,0 +1,13 @@
+defmodule Honeybadger.Metrics.Supervisor do
+  use Supervisor
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [])
+  end
+
+  def init([]) do
+    child = worker(Honeybadger.Metrics.Server, [])
+    supervise([child], strategy: :one_for_one)
+  end
+
+end

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -1,0 +1,33 @@
+defmodule Honeybadger.ClientTest do
+  use ExUnit.Case, async: true
+  alias Honeybadger.Client
+
+  test "sending metrics" do
+    client = Client.new
+    metrics = [123, 456, 789, 134, 567, 890, 234, 567, 901]
+    metric = Honeybadger.Metric.new(metrics)
+    request = Client.send_metric(client, metric, FakeHttp)
+
+    assert %{
+      "body" => %{
+        "metrics" => [
+          "app.request.200:stddev #{metric.stddev}",
+          "app.request.200:percentile_90 #{metric.percentile_90}",
+          "app.request.200:min #{metric.min}",
+          "app.request.200:median #{metric.median}",
+          "app.request.200:mean #{metric.mean}",
+          "app.request.200:max #{metric.max}",
+          "app.request.200 #{metric.count}"
+        ],
+        "environment" => "test",
+        "hostname" => Application.get_env(:honeybadger, :hostname)
+      },
+      "headers" => [
+        {"Accept", "application/json"},
+        {"Content-Type", "application/json"},
+        {"X-API-Key", "abc123"}
+      ],
+      "url" => "https://localhost:4000/v1/metrics",
+    } == request
+  end
+end

--- a/test/metric_test.exs
+++ b/test/metric_test.exs
@@ -1,0 +1,19 @@
+defmodule Honeybadger.MetricTest do
+  use ExUnit.Case
+  alias Honeybadger.Metric
+
+  test "creating metrics from a list of response times" do
+    responses = [122, 87, 820, 45, 731]
+
+    metric = Metric.new(responses)
+
+    assert metric == %Metric{
+      max: 820,
+      mean: 361.0,
+      median: 122,
+      min: 45, 
+      percentile_90: 820, 
+      stddev: 340.48,
+      count: 5}
+  end
+end

--- a/test/metrics/math_test.exs
+++ b/test/metrics/math_test.exs
@@ -1,0 +1,42 @@
+defmodule Metrics.MathTest do
+  use ExUnit.Case, async: true
+  alias Honeybadger.Metrics.Math
+
+  setup do
+    requests = [122, 87, 820, 45, 731]
+    {:ok, %{requests: requests}}
+  end
+
+  test "mean", %{requests: requests} do
+    assert 361.0 == Math.mean(requests)
+    assert 0     == Math.mean([])
+  end
+
+  test "median", %{requests: requests} do
+    assert 122 == Math.median(requests)
+    assert 0   == Math.median([])
+  end
+
+  test "max", %{requests: requests} do
+    assert 820 == Math.max(requests)
+    assert 0   == Math.max([])
+  end
+
+  test "min", %{requests: requests} do
+    assert 45 == Math.min(requests)
+    assert 0  == Math.min([])
+  end
+
+  test "standard deviation", %{requests: requests} do
+    assert 340.48 == Math.standard_deviation(requests)
+    assert 0      == Math.standard_deviation([])
+  end
+
+  test "calculating the percentile", %{requests: requests} do
+    assert 104.5 == Math.percentile(requests, 0.40)
+    assert 820  == Math.percentile(requests, 0.90)
+    assert Math.percentile(requests, 90) == Math.percentile(requests, 0.90)
+    assert Math.percentile(requests, 50) == Math.percentile(requests, 0.50)
+  end
+
+end

--- a/test/metrics/server_text.exs
+++ b/test/metrics/server_text.exs
@@ -1,0 +1,25 @@
+defmodule MetricServerTest do
+  use ExUnit.Case, async: true
+  alias Honeybadger.Metrics
+
+  test "adding and flushing request times" do
+    Metrics.Server.timing(122)
+    Metrics.Server.timing(87)
+
+    server = Process.whereis(Metrics.Server)
+    assert :sys.get_state(server) == %{timings: [87, 122], interval: 60000}
+
+    send(server, :flush)
+    assert :sys.get_state(server) == %{timings: [], interval: 60000}
+  end
+
+  test "being flushed by the scheduled interval" do
+    {:ok, server} = Metrics.Server.start_link(10, :test_metrics_server)
+
+    Metrics.Server.timing(122)
+    Metrics.Server.timing(87)
+
+    :timer.sleep(10)
+    assert :sys.get_state(server) == %{timings: [], interval: 10}
+  end
+end

--- a/test/support/fake_http.exs
+++ b/test/support/fake_http.exs
@@ -1,0 +1,11 @@
+defmodule FakeHttp do
+  alias Poison, as: JSON
+
+  def post(url, body, headers) do
+    body = JSON.decode!(body)
+
+    %{"url" => url,
+      "body" => body,
+      "headers" => headers}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
 Logger.remove_backend :console
 Code.load_file("test/support/error_server.exs")
+Code.load_file("test/support/fake_http.exs")
+
 ExUnit.start()


### PR DESCRIPTION
This PR adds integration with the Honeybadger API for metrics. Request metrics are gathered from Phoenix and Plug apps and then sent to Honeybadger for analysis.

This PR also adds a Supervision tree which should resolve issue #32.

Another notable change is the creation of `Honeybadger.Client`. This module and its accompanying struct extract the logic for sending notices and metrics to the Honeybadger API.