### PR TITLE
fix convert unit bug

### DIFF
--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -14,7 +14,7 @@ defmodule Honeybadger.Plug do
           conn = super(conn, opts)
 
           after_response = :erlang.monotonic_time
-          response_time = :erlang.convert_time_unit(after_response - before_response, :micro_seconds)
+          response_time = :erlang.convert_time_unit(after_response - before_response, :native, :micro_seconds)
           Honeybadger.Metrics.Server.timing(response_time)
           conn
         catch


### PR DESCRIPTION
Related to #48 and #42 

`:erlang.convert_time_unit` expects 3 arguments, so this should fix the issue.