### PR TITLE
reformat notice request payload

### DIFF
--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -12,7 +12,9 @@ defmodule Honeybadger.Notice do
       tags: Dict.get(metadata, :tags, []),
       backtrace: backtrace
     }
-    request = Dict.take(metadata, [:plug_env, :context])
+    context = Dict.get(metadata, :context, %{})
+    request = Dict.get(metadata, :plug_env, %{})
+              |> Dict.put(:context, context)
 
     %__MODULE__{error: error,
                 request: request,

--- a/test/notice_test.exs
+++ b/test/notice_test.exs
@@ -51,12 +51,10 @@ defmodule Honeybadger.NoticeTest do
 
   test "request information", %{notice: %Notice{request: request}} do
     assert %{
-      plug_env: %{
-        action: :show,
-        component: SomeApp.PageController,
-        params: %{page: 1},
-        url: "/pages/1"
-      }
+      action: :show,
+      component: SomeApp.PageController,
+      params: %{page: 1},
+      url: "/pages/1"
     } == Dict.drop(request, [:context])
 
     assert %{user_id: 1, account_id: 1} == request[:context]


### PR DESCRIPTION
Our Honeybadger reports were missing things like params, route, environment, etc. and based on http://docs.honeybadger.io/guides/api.html, it looks like it is because the keys held in the `plug_env` map should be at top level of the `request` key in the payload.

I tested it in our development environment, and it started to include more things (params, URL, browser) on the error page, but not longer afterwards, I noticed that on a different environment, this extra data started to show up on the error page as well, even though it was still using the the currently incorrect format.  Did something change on how the `plug_env` key is handled, and is this change still necessary?