### PR TITLE
Remove `use Plug.ErrorHandler`

### DIFF
--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -4,7 +4,6 @@ defmodule Honeybadger.Plug do
   defmacro __using__(_env) do
     quote do
       import Honeybadger.Plug
-      use Plug.ErrorHandler
       require Honeybadger
 
       def call(conn, opts) do


### PR DESCRIPTION
Having the `use` statement causes double logging because both
the `Honeybadger.Plug` and the `Plug.ErrorHandler` attempt to catch
the error then call the same `handle_errors/2` function.