### PR TITLE
Suppress metric HTTP calls in excluded environments

### DIFF
--- a/lib/honeybadger/metrics/server.ex
+++ b/lib/honeybadger/metrics/server.ex
@@ -1,7 +1,7 @@
 defmodule Honeybadger.Metrics.Server do
   use GenServer
+  require Honeybadger
   alias Honeybadger.Metric
-  alias Honeybadger.Client
 
   @moduledoc """
     This GenServer receives metrics (the response time) from
@@ -44,9 +44,8 @@ defmodule Honeybadger.Metrics.Server do
 
   def handle_info(:flush, state) do
     schedule_flush_message(state[:interval])
-    client = Client.new
     metric = Metric.new(state[:timings])
-    Client.send_metric(client, metric, HTTPoison)
+    Honeybadger.send_metric(metric)
     {:noreply, Map.put(state, :timings, [])}
   end
 


### PR DESCRIPTION
In excluded environments, HTTP calls were suppressed for error notifications, but not for metrics reporting. This resulted in error logging noise during test runs, when ExVCR complained about un-mocked HTTP calls.

![honeybadger-exvcr-noise](https://cloud.githubusercontent.com/assets/86996/22089200/6605d00a-dd9e-11e6-80fd-2983fd1edaef.png)
