### PR TITLE
Relax poison version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Honeybadger.Mixfile do
 
   defp deps do
     [{:httpoison, "~> 0.9"},
-     {:poison, "~> 3.0"},
+     {:poison, "~> 2.0 or ~> 3.0"},
      {:plug, ">= 0.13.0 and < 2.0.0"},
 
      # Dev dependencies

--- a/mix.lock
+++ b/mix.lock
@@ -9,5 +9,5 @@
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []}}


### PR DESCRIPTION
- The latest version of Phoenix only supports Poison 2.2
- This will allow for the latest version of Poison but will also allow older versions to work