### PR TITLE
Make inactive and active environments more similar

### DIFF
--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -178,18 +178,12 @@ defmodule Honeybadger do
     client = Client.new
     backtrace = Backtrace.from_stacktrace(stacktrace)
     notice = Notice.new(exception, metadata, backtrace)
-    Client.send_notice(client, notice, active_environment?())
+    Client.send_notice(client, notice)
   end
 
   def do_notify(exception, metadata, stacktrace) do
     metadata = %{context: metadata}
     do_notify(exception, metadata, stacktrace)
-  end
-
-  def active_environment? do
-    env = Application.get_env(:honeybadger, :environment_name)
-    exclude_envs = Application.get_env(:honeybadger, :exclude_envs, [:dev, :test])
-    not env in exclude_envs
   end
 
   def context do

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -16,11 +16,14 @@ defmodule Honeybadger.Client do
                 hostname: hostname}
   end
 
-  def send_notice(%__MODULE__{} = client, notice, http_mod \\ HTTPoison) do
-    body = JSON.encode!(notice)
-
+  def send_notice(%__MODULE__{} = client, notice, http_mod \\ HTTPoison, active_environment) do
+    encoded_notice = JSON.encode!(notice)
+    do_send_notice(client, encoded_notice, http_mod, active_environment)
+  end
+  defp do_send_notice(_client, _encoded_notice, _http_mod, false), do: {:ok, :unsent}
+  defp do_send_notice(client, encoded_notice, http_mod, true) do
     http_mod.post(
-      client.origin <> @notices_endpoint, notice, client.headers
+      client.origin <> @notices_endpoint, encoded_notice, client.headers
     )
   end
 

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -16,9 +16,9 @@ defmodule Honeybadger.Client do
                 hostname: hostname}
   end
 
-  def send_notice(%__MODULE__{} = client, notice, http_mod \\ HTTPoison, active_environment) do
+  def send_notice(%__MODULE__{} = client, notice, http_mod \\ HTTPoison) do
     encoded_notice = JSON.encode!(notice)
-    do_send_notice(client, encoded_notice, http_mod, active_environment)
+    do_send_notice(client, encoded_notice, http_mod, active_environment?())
   end
   defp do_send_notice(_client, _encoded_notice, _http_mod, false), do: {:ok, :unsent}
   defp do_send_notice(client, encoded_notice, http_mod, true) do
@@ -31,6 +31,12 @@ defmodule Honeybadger.Client do
     [{"Accept", "application/json"},
      {"Content-Type", "application/json"},
      {"X-API-Key", api_key}]
+  end
+
+  def active_environment? do
+    env = Application.get_env(:honeybadger, :environment_name)
+    exclude_envs = Application.get_env(:honeybadger, :exclude_envs, [:dev, :test])
+    not env in exclude_envs
   end
 
 end

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -44,11 +44,6 @@ defmodule HoneybadgerTest do
   test "sending a notice on an inactive environment doesn't make an HTTP request" do
     assert [:dev, :test] == Application.get_env(:honeybadger, :exclude_envs)
 
-    url = Application.get_env(:honeybadger, :origin) <> "/v1/notices"
-    headers = [{"Accept", "application/json"},
-               {"Content-Type", "application/json"},
-               {"X-API-Key", "at3stk3y"}]
-
     defmodule InactiveSample do
       def notify do
         Honeybadger.notify(%RuntimeError{}, %{})

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -11,10 +11,15 @@ defmodule HoneybadgerTest do
     on_exit(fn ->
       Application.put_env :honeybadger, :api_key, before
     end)
+
+    :meck.expect(HTTP, :post, fn(_url, _data, _headers) -> %HTTP.Response{} end)
+
+    on_exit(fn ->
+      :meck.unload(HTTP)
+    end)
   end
 
-  test "sending a notice" do
-    :meck.expect(HTTP, :post, fn(_url, _data, _headers) -> %HTTP.Response{} end)
+  test "sending a notice on an active environment" do
     Application.put_env(:honeybadger, :exclude_envs, [])
 
     url = Application.get_env(:honeybadger, :origin) <> "/v1/notices"
@@ -22,18 +27,38 @@ defmodule HoneybadgerTest do
                {"Content-Type", "application/json"},
                {"X-API-Key", "at3stk3y"}]
 
-    defmodule Sample do
+    defmodule ActiveSample do
       def notify do
         Honeybadger.notify(%RuntimeError{}, %{})
       end
     end
 
-    Sample.notify
+    {:ok, _} = ActiveSample.notify
     :timer.sleep 250
 
-    assert :meck.called(HTTP, :post, [url, :_, headers])
+    assert :meck.called(HTTP, :post, [url, :meck.is(fn(data) -> is_binary(data) end), headers])
   after
     Application.put_env(:honeybadger, :exclude_envs, [:dev, :test])
+  end
+
+  test "sending a notice on an inactive environment doesn't make an HTTP request" do
+    assert [:dev, :test] == Application.get_env(:honeybadger, :exclude_envs)
+
+    url = Application.get_env(:honeybadger, :origin) <> "/v1/notices"
+    headers = [{"Accept", "application/json"},
+               {"Content-Type", "application/json"},
+               {"X-API-Key", "at3stk3y"}]
+
+    defmodule InactiveSample do
+      def notify do
+        Honeybadger.notify(%RuntimeError{}, %{})
+      end
+    end
+
+    {:ok, _} = InactiveSample.notify
+    :timer.sleep 250
+
+    refute :meck.called(HTTP, :post, [:_, :_, :_])
   end
 
   test "getting and setting the context" do
@@ -46,8 +71,4 @@ defmodule HoneybadgerTest do
     assert %{user_id: 2} == Honeybadger.context()
   end
 
-  test "calls at compile time are removed in exclude environments" do
-    assert [:dev, :test] == Application.get_env(:honeybadger, :exclude_envs)
-    assert :ok == Honeybadger.notify(%RuntimeError{})
-  end
 end


### PR DESCRIPTION
From what I explained in #79.

With these changes I'm trying to make inactive and active environments behave more similarly. The only difference is that now it's the `Client` that ultimately does not make any HTTP request.

Also, make sure the `Client` POSTs the encoded notice (as binary) and not the notice as-is; it looks like a regression while removing the metrics.

There's room for improvement but I'd like to know if you think this goes in the right direction.