### PR TITLE
Add get_env/1 to universally support system variables

### DIFF
--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -197,6 +197,21 @@ defmodule Honeybadger do
     context()
   end
 
+  @doc """
+  Fetch configuration specific to the :honeybadger application.
+  """
+  @spec get_env(atom) :: any | no_return
+  def get_env(key) when is_atom(key) do
+    case Application.fetch_env(:honeybadger, key) do
+      {:ok, {:system, var}} when is_binary(var) ->
+        System.get_env(var) || raise ArgumentError, "system variable #{inspect(var)} is not set"
+      {:ok, value} ->
+        value
+      :error ->
+        raise ArgumentError, "the configuration parameter #{inspect(key)} is not set"
+    end
+  end
+
   defp default_config do
      [api_key: System.get_env("HONEYBADGER_API_KEY"),
       exclude_envs: [:dev, :test],

--- a/lib/honeybadger/backtrace.ex
+++ b/lib/honeybadger/backtrace.ex
@@ -21,7 +21,7 @@ defmodule Honeybadger.Backtrace do
   end
 
   defp otp_app do
-    Application.get_env(:honeybadger, :app)
+    Honeybadger.get_env(:app)
   end
 
   defp get_context(app, app) when app != nil, do: "app"

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -10,12 +10,13 @@ defmodule Honeybadger.Client do
   ]
 
   def new do
-    origin = Application.get_env(:honeybadger, :origin)
-    api_key = Application.get_env(:honeybadger, :api_key)
-    env_name = Application.get_env(:honeybadger, :environment_name)
-    hostname = Application.get_env(:honeybadger, :hostname)
-    proxy = Application.get_env(:honeybadger, :proxy)
-    proxy_auth = Application.get_env(:honeybadger, :proxy_auth)
+    origin = Honeybadger.get_env(:origin)
+    api_key = Honeybadger.get_env(:api_key)
+    env_name = Honeybadger.get_env(:environment_name)
+    hostname = Honeybadger.get_env(:hostname)
+    proxy = Honeybadger.get_env(:proxy)
+    proxy_auth = Honeybadger.get_env(:proxy_auth)
+
     %__MODULE__{origin: origin,
                 headers: headers(api_key),
                 environment_name: env_name,
@@ -48,10 +49,10 @@ defmodule Honeybadger.Client do
     [{"X-API-Key", api_key}] ++ @headers
   end
 
-  def active_environment? do
-    env = Application.get_env(:honeybadger, :environment_name)
-    exclude_envs = Application.get_env(:honeybadger, :exclude_envs, [:dev, :test])
+  defp active_environment? do
+    env = Honeybadger.get_env(:environment_name)
+    exclude_envs = Honeybadger.get_env(:exclude_envs)
+
     not env in exclude_envs
   end
-
 end

--- a/lib/honeybadger/filter.ex
+++ b/lib/honeybadger/filter.ex
@@ -92,7 +92,7 @@ defmodule Honeybadger.FilterMixin do
       def filter_error_message(message), do: message
 
       defp filter_map(map) do
-        case Application.get_env(:honeybadger, :filter_keys) do
+        case Honeybadger.get_env(:filter_keys) do
           keys when is_list(keys) ->
             filter_keys = Enum.map(keys, &canonicalize(&1))
             drop_keys = Enum.filter(Map.keys(map),
@@ -114,7 +114,7 @@ defmodule Honeybadger.DefaultNoticeFilter do
   @behaviour Honeybadger.NoticeFilter
 
   def filter(%Honeybadger.Notice{} = notice) do
-    if filter = Application.get_env(:honeybadger, :filter) do
+    if filter = Honeybadger.get_env(:filter) do
       notice
       |> Map.put(:request, filter_request(notice.request, filter))
       |> Map.put(:error, filter_error(notice.error, filter))
@@ -147,9 +147,11 @@ defmodule Honeybadger.DefaultNoticeFilter do
   end
 
   defp disable(request, config_key, map_key) do
-    if Application.get_env(:honeybadger, config_key),
-      do: request |> Map.drop([map_key]),
-      else: request
+    if Honeybadger.get_env(config_key) do
+      request |> Map.drop([map_key])
+    else
+      request
+    end
   end
 end
 

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -37,7 +37,7 @@ defmodule Honeybadger.Notice do
                 request: request,
                 notifier: notifier(),
                 server: server()}
-     |> filter(Application.get_env(:honeybadger, :notice_filter))
+     |> filter(Honeybadger.get_env(:notice_filter))
   end
 
   url = get_in(Honeybadger.Mixfile.project, [:package, :links, "GitHub"])
@@ -53,20 +53,8 @@ defmodule Honeybadger.Notice do
   end
 
   defp server do
-    %{environment_name: environment_name(),
-      hostname: hostname(),
-      project_root: project_root()}
-  end
-
-  defp hostname do
-    Application.get_env(:honeybadger, :hostname)
-  end
-
-  defp project_root do
-    Application.get_env(:honeybadger, :project_root)
-  end
-
-  defp environment_name do
-    Application.get_env(:honeybadger, :environment_name)
+    %{environment_name: Honeybadger.get_env(:environment_name),
+      hostname: Honeybadger.get_env(:hostname),
+      project_root: Honeybadger.get_env(:project_root)}
   end
 end

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -68,7 +68,7 @@ defmodule Honeybadger.Plug do
       "REMOTE_ADDR" => get_remote_addr(conn.remote_ip),
       "REMOTE_PORT" => get_remote_port(conn.peer),
       "SERVER_ADDR" => "127.0.0.1",
-      "SERVER_NAME" => Application.get_env(:honeybadger, :hostname),
+      "SERVER_NAME" => Honeybadger.get_env(:hostname),
       "SERVER_PORT" => conn.port,
       "CONTENT_LENGTH" => Plug.Conn.get_req_header(conn, "content-length"),
       "ORIGINAL_FULLPATH" => conn.request_path


### PR DESCRIPTION
This adds a `Honeybadger.get_env/1` function that universally fetches application or system variables via `:system` tuples. Resolution works as follows:

* If a value from `{:system, "ENV_NAME"}`  is missing it raises an `ArgumentError`, indicating the missing "ENV_NAME".
* If the requested env key is unknown it raises an `ArgumentError` stating that the key has not been set.

After adding the system tuple support I updated the few uses of `System.get_env`. This removes any reliance on the system env during compile time, which simplifies configuring releases or deploying to Heroku.