### PR TITLE
More idiomatic stringifying of modules

### DIFF
--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -31,7 +31,7 @@ defmodule Honeybadger.Logger do
       end
     rescue
       ex ->
-        error_type = Utils.strip_elixir_prefix(ex.__struct__)
+        error_type = Utils.module_to_string(ex.__struct__)
         reason = Exception.message(ex)
         message = "Unable to notify Honeybadger! #{error_type}: #{reason}"
         Logger.warn(message)

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -20,7 +20,7 @@ defmodule Honeybadger.Notice do
     exception = Exception.normalize(:error, exception)
     exception_mod = exception.__struct__
     error = %{
-      class: Utils.strip_elixir_prefix(exception_mod),
+      class: Utils.module_to_string(exception_mod),
       message: exception_mod.message(exception),
       tags: Map.get(metadata, :tags, []),
       backtrace: backtrace

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -51,7 +51,7 @@ defmodule Honeybadger.Plug do
            |> Plug.Conn.fetch_query_params
 
     %{url: conn.request_path,
-      component: Utils.strip_elixir_prefix(mod),
+      component: Utils.module_to_string(mod),
       action: "",
       params: conn.params,
       session: session,

--- a/lib/honeybadger/utils.ex
+++ b/lib/honeybadger/utils.ex
@@ -1,17 +1,20 @@
 defmodule Honeybadger.Utils do
   @moduledoc """
-    Assorted helper functions used through out the Honeybadger package
+  Assorted helper functions used through out the Honeybadger package.
   """
 
   @doc """
-    Internally all modules are prefixed with Elixir. This function removes the
-    Elixir prefix from the module when it is converted to a string.
+  Internally all modules are prefixed with Elixir. This function removes the
+  `Elixir` prefix from the module when it is converted to a string.
+
+  # Example
+
+      iex> Honeybadger.Utils.module_to_string(Honeybadger.Utils)
+      "Honeybadger.Utils"
   """
-  def strip_elixir_prefix(module) do
+  def module_to_string(module) do
     module
-    |> Atom.to_string
-    |> String.split(".")
-    |> tl
+    |> Module.split()
     |> Enum.join(".")
   end
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,11 +1,5 @@
 defmodule Honeybadger.UtilsTest do
   use ExUnit.Case, async: true
-  import Honeybadger.Utils
 
-  test "strip_elixir_prefix removes Elixir from a module name" do
-    stripped = strip_elixir_prefix(Honeybadger.Notice)
-
-    assert "Honeybadger.Notice" == stripped
-    refute String.starts_with?(stripped, "Elixir.")
-  end
+  doctest Honeybadger.Utils
 end


### PR DESCRIPTION
The `Module.split/1` function is specifically designed to deconstruct module names _without_ the `Elixir.` prefix. This replaces the custom stripping function with a more idiomatic approach, and uses a more revealing name for the function.