### PR TITLE
Update the CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: elixir
 elixir:
   - 1.2.6
   - 1.3.4
-  - 1.4.0
+  - 1.4.4
+  - 1.5.1
 otp_release:
-  - 18.3
+  - 19.3


### PR DESCRIPTION
The matrix lacked a 1.5 release. Additionally, all of the versions within the matrix are compatible with OTP 19, which is likely to be the oldest OTP most applications are running on now.