### PR TITLE
Add a mix task for publishing on hex and creating git tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ will be accepted.
 5. Push to your branch `git push origin my_branch`
 6. Send a [pull request](https://github.com/honeybadger-io/honeybadger-elixir/pulls)
 
+### Publishing a release on hex.pm
+
+1. Update the version property in `mix.exs`
+2. Create a git commit with all the changes so that your working directory is clean
+3. Run `mix release` from your terminal, which will do the following:
+    1. Upload the new version of honeybadger to hex.pm
+    2. Create a git tag with the version number and push it to GitHub
+
 ### License
 
 This library is MIT licensed. See the

--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Release do
+  use Mix.Task
+
+  @shortdoc "Publish package to hex.pm, create a git tag and push it to GitHub"
+
+  @moduledoc """
+  release uses shipit.
+  It performs many sanity checks before pushing the hex package.
+  Check out https://github.com/wojtekmach/shipit for more details
+  """
+
+  def run([]) do
+    ensure_shipit_installed!()
+    Mix.Task.run("shipit", ["master", current_version()])
+  end
+
+  def run(_) do
+    Mix.raise("""
+    Invalid args.
+
+    Usage:
+
+      mix release
+    """)
+  end
+
+  defp ensure_shipit_installed! do
+    loadpaths!()
+    Mix.Task.load_all()
+    if !Mix.Task.get("shipit") do
+      Mix.raise("""
+      You don't seem to have the shipit mix task installed on your computer.
+      Install it using:
+
+        mix archive.install hex shipit
+
+        Fore more info go to: https://github.com/wojtekmach/shipit
+      """)
+    end
+  end
+
+  defp current_version do
+    Mix.Project.config[:version]
+  end
+
+  # Copied from Mix.Tasks.Help
+  # Loadpaths without checks because tasks may be defined in deps.
+  defp loadpaths! do
+    Mix.Task.run "loadpaths", ["--no-elixir-version-check", "--no-deps-check", "--no-archives-check"]
+    Mix.Task.reenable "loadpaths"
+    Mix.Task.reenable "deps.loadpaths"
+  end
+
+end


### PR DESCRIPTION
This adds a `hex_publish` mix task, which does the things mentioned on #95 