### PR TITLE
Honeybadger test mix task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](http://semver.org/).
   (honeybadger-io/honeybadger-elixir#20).
 - Explicitly allow sending notices with strings and maps. For example, it is now
   possible to send a `RuntimeError` by calling `Honeybadger.notify("oops!")`.
+- Added Honeybadger test mix task which can be invoked using `mix honeybadger.test`
 
 ### Changed
 - Use the latest exception's stacktrace whenever `notify` is called from a

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ config :honeybadger,
 config :honeybadger,
   exclude_envs: [:test]
 ```
+3. Run the `mix honeybadger.test` mix task task to simulate an error
 
 ## Changelog
 

--- a/lib/mix/tasks/test.ex
+++ b/lib/mix/tasks/test.ex
@@ -1,0 +1,77 @@
+defmodule HoneybadgerTestingException do
+  defexception message: """
+  Testing honeybadger via `mix honeybadger.test`. If you can see this, it works.
+  """
+end
+
+defmodule Mix.Tasks.Honeybadger.Test do
+  use Mix.Task
+
+  @shortdoc "Verify your hex package installation by sending a test exception to the honeybadger service"
+
+  def run(_) do
+    with :ok <- assert_env() do
+      send_notice()
+    end
+  end
+
+  defp send_notice do
+
+    # mute excluded envs
+    Application.put_env(:honeybadger, :exclude_envs, [])
+
+    {:ok, _started} = Application.ensure_all_started(:honeybadger)
+
+    # send the notification
+    Honeybadger.notify(%HoneybadgerTestingException{})
+
+    # this will block the mix task from stopping before
+    # the genserver sends the notification to honeybadger
+    Honeybadger.Client |> Process.whereis |> GenServer.stop
+
+    # if there is no error till this point, we should assume that our notice succeeded
+
+    Mix.shell().info """
+    Raising 'HoneybadgerTestingException' to simulate application failure.
+    ⚡ --- Honeybadger is installed! -----------------------------------------------
+
+    Good news: You're one deploy away from seeing all of your exceptions in
+    Honeybadger. For now, we've generated a test exception for you.
+
+    If you ever need help:
+
+    - Check out our documentation: https://hexdocs.pm/honeybadger
+    - Email the founders: support@honeybadger.io
+
+    Most people don't realize that Honeybadger is a small, bootstrapped company. We
+    really couldn't do this without you. Thank you for allowing us to do what we
+    love: making developers awesome.
+
+    Happy 'badgering!
+
+    Sincerely,
+    Ben, Josh and Starr
+    https://www.honeybadger.io/about/
+
+    ⚡ --- End --------------------------------------------------------------------
+    """
+  end
+
+  defp assert_env do
+    try do
+      Mix.Task.run "app.start" # to be able to read the env
+      Honeybadger.get_env(:api_key)
+      :ok
+    rescue
+      _ ->
+        Mix.shell().error """
+        Your api_key is not set
+        Set it either in your config file or using the HONEYBADGER_API_KEY environment variable
+
+        For more info visit: https://github.com/honeybadger-io/honeybadger-elixir#2-set-your-api-key-and-environment-name
+        """
+        :error
+    end
+  end
+
+end

--- a/mix.lock
+++ b/mix.lock
@@ -8,9 +8,9 @@
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
-  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [repo: "hexpm", hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [repo: "hexpm", hex: :mime, optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ranch": {:hex, :ranch, "1.4.0", "10272f95da79340fa7e8774ba7930b901713d272905d0012b06ca6d994f8826b", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
Adds the ability to simulate an error using a mix task. Completes #36 