### PR TITLE
Re-implement error logger using gen_event behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](http://semver.org/).
   possible to send a `RuntimeError` by calling `Honeybadger.notify("oops!")`.
 
 ### Changed
+- Switch from `GenEvent` to implementing `gen_event` behaviour.
+- Remove `error_logger` backend on application stop.
 - Use the latest exception's stacktrace whenever `notify` is called from a
   `try` expression.
 - Namespace modules related to `Filter` and `NoticeFilter`. This is largely an

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -159,6 +159,13 @@ defmodule Honeybadger do
     Supervisor.start_link(children, strategy: :one_for_one)
   end
 
+  @doc false
+  def stop(_state) do
+    :error_logger.delete_report_handler(Honeybadger.Logger)
+
+    :ok
+  end
+
   @doc """
   Send an exception notification, if reporting is enabled.
 

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -1,27 +1,55 @@
 defmodule Honeybadger.Logger do
-  alias Honeybadger.Utils
+  @moduledoc false
+
+  @behaviour :gen_event
 
   require Logger
 
-  use GenEvent
+  alias Honeybadger.Utils
 
-  def init(_mod, []), do: {:ok, []}
+  def init(args) do
+    {:ok, args}
+  end
+
+  ## Callbacks
+
+  def handle_event({_type, gl, _msg}, state) when node(gl) != node() do
+    {:ok, state}
+  end
+
+  def handle_event(event, state) do
+    handle_error(event, state)
+
+    {:ok, state}
+  end
 
   def handle_call({:configure, new_keys}, _state) do
     {:ok, :ok, new_keys}
   end
 
-  def handle_event({_level, gl, _event}, state)
-      when node(gl) != node() do
+  def handle_call(request, _state) do
+    exit {:bad_call, request}
+  end
+
+  def handle_info(_msg, state) do
     {:ok, state}
   end
 
-  def handle_event({:error_report, _gl, {_pid, _type, [message | _]}}, state)
+  def code_change(_old_vsn, state, _extra) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  ## Helpers
+
+  defp handle_error({:error_report, _gl, {_pid, _type, [message | _]}}, _state)
       when is_list(message) do
     try do
       error_info = message[:error_info]
       context = get_in(message, [:dictionary, :honeybadger_context])
-      context = %{context: context}
 
       case error_info do
         {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
@@ -38,11 +66,9 @@ defmodule Honeybadger.Logger do
           "Unable to notify Honeybadger! #{error_type}: #{reason}"
         end)
     end
-
-    {:ok, state}
   end
 
-  def handle_event({_level, _gl, _event}, state) do
-    {:ok, state}
+  defp handle_error(_event, _state) do
+    :ok
   end
 end

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -18,7 +18,7 @@ defmodule Honeybadger.Logger do
   end
 
   def handle_event(event, state) do
-    handle_error(event, state)
+    handle_error(event)
 
     {:ok, state}
   end
@@ -45,14 +45,12 @@ defmodule Honeybadger.Logger do
 
   ## Helpers
 
-  defp handle_error({:error_report, _gl, {_pid, _type, [message | _]}}, _state)
-      when is_list(message) do
+  defp handle_error({:error_report, _gl, {_pid, _type, [message | _]}}) when is_list(message) do
     try do
-      error_info = message[:error_info]
       context = get_in(message, [:dictionary, :honeybadger_context])
 
-      case error_info do
-        {_kind, {exception, stacktrace}, _stack} when is_list(stacktrace) ->
+      case message[:error_info] do
+        {_kind, {exception, stacktrace}, _stack} ->
           Honeybadger.notify(exception, context, stacktrace)
         {_kind, exception, stacktrace} ->
           Honeybadger.notify(exception, context, stacktrace)
@@ -68,7 +66,7 @@ defmodule Honeybadger.Logger do
     end
   end
 
-  defp handle_error(_event, _state) do
+  defp handle_error(_event) do
     :ok
   end
 end

--- a/test/honeybadger/logger_test.exs
+++ b/test/honeybadger/logger_test.exs
@@ -17,14 +17,6 @@ defmodule Honeybadger.LoggerTest do
     end
   end
 
-  setup_all do
-    :error_logger.add_report_handler(Honeybadger.Logger)
-
-    on_exit fn ->
-      :error_logger.delete_report_handler(Honeybadger.Logger)
-    end
-  end
-
   setup do
     {:ok, _} = Honeybadger.API.start(self())
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,7 +12,7 @@ defmodule Honeybadger.Case do
   end
 
   def with_config(opts, fun) when is_function(fun) do
-    original = Keyword.take(Application.get_all_env(:honeybadger), Keyword.keys(opts))
+    original = take_original_env(opts)
 
     try do
       put_all_env(opts)
@@ -25,7 +25,7 @@ defmodule Honeybadger.Case do
 
   def restart_with_config(opts) do
     :ok = Application.stop(:honeybadger)
-    original = Keyword.take(Application.get_all_env(:honeybadger), Keyword.keys(opts))
+    original = take_original_env(opts)
 
     put_all_env(opts)
 
@@ -48,6 +48,10 @@ defmodule Honeybadger.Case do
       :timer.sleep(100)
       Logger.flush()
     end)
+  end
+
+  defp take_original_env(opts) do
+    Keyword.take(Application.get_all_env(:honeybadger), Keyword.keys(opts))
   end
 
   defp put_all_env(opts) do


### PR DESCRIPTION
* Implement `Honeybadger.stop/1` callback to de-register the error logger when the supervision tree is shut down.
* Prevent registering duplicate loggers in tests, this interfered with correctly testing api responses.
* Remove use of `GenEvent`, replacing it with direct use of the `gen_event` behaviour. No more deprecation warnings!
* Add more detailed assertions in the logger tests, now the error "class" and the context are asserted.