### PR TITLE
Safely handle unknown environment values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Safely convert binary `:environment_name` values to an atom. If the
+  environment was specified via `{:system, "HONEYBADGER_ENV"}` and the
+  `HONEYBADGER_ENV` value didn't already exist as an atom the app would fail to
+  boot.
+
 ## [v0.7.0] - 2017-11-07
 ### Added
 - Increases the logging around client activity

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -56,6 +56,9 @@ defmodule Honeybadger.Client do
 
       iex> Honeybadger.Client.enabled?(environment_name: :dev, exclude_envs: [:test])
       true
+
+      iex> Honeybadger.Client.enabled?(environment_name: "unexpected", exclude_envs: [:test])
+      true
   """
   @spec enabled?(Keyword.t) :: boolean
   def enabled?(opts) do
@@ -125,7 +128,7 @@ defmodule Honeybadger.Client do
   end
 
   defp maybe_to_atom(value) when is_binary(value) do
-    String.to_existing_atom(value)
+    String.to_atom(value)
   end
 
   defp maybe_to_atom(value) do


### PR DESCRIPTION
The use of `String.to_existing_atom/1` would cause the client to crash if an unknown binary was provided. For example, on a staging server using a `{:system, "HONEYBADGER_ENV"}` tuple, the app would fail to boot.

This replaces `to_existing_atom/1` with `to_atom`.