### PR TITLE
Include params and arity in formatted backtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Include function arity in notice backtraces. For example, the reported method
+  would be `notify/3` instead of `notify`.
+- Include function arguments in notice backtraces. This is disabled by default,
+  and can be enabled by setting `filter_args` to `false` in configuration.
 
 ## [v0.7.0] - 2017-11-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ config :honeybadger,
 If `environment_name` is not set we will fall back to the value of `Mix.env()`.
 `Mix.env()` uses the atomized value of the `MIX_ENV` environment variable and
 defaults to `:dev` when the environment variable is not set. This should be good
-for most setups. If you want to have an environment_name which is different than
+for most setups. If you want to have an `environment_name` which is different than
 the `Mix.env()`, you should set `environment_name` in your `config.exs` files for each
 environment. This ensures that we can give you accurate environment information
 even during compile time. Explicitly setting the `environment_name` config
@@ -140,7 +140,7 @@ config :honeybadger,
   filter_keys: [:password, :credit_card]
 ```
 
-This will remove any entries in the context, session, cgi_data and params that match one of the filter keys.  The filter is case insensitive and matches atoms or strings.
+This will remove any entries in the `context`, `session`, `cgi_data` and `params` that match one of the filter keys.  The filter is case insensitive and matches atoms or strings.
 
 If `Honeybadger.Filter.Default` does not suit your needs, you can implement your own filter. See the `Honeybadger.Filter.Mixin` module doc for details on implementing your own filter.
 
@@ -157,22 +157,23 @@ config :honeybadger,
 
 Here are all of the options you can pass in the keyword list:
 
-| Name         | Description                                                               | Default |
-|--------------|---------------------------------------------------------------------------|---------|
-| api_key      | Your application's Honeybadger API key                                    | System.get_env("HONEYBADGER_API_KEY"))` |
-| environment_name | (required) The name of the environment your app is running in.                   | nil |
-| app          | Name of your app's OTP Application as an atom                             | Mix.Project.config[:app] |
-| use_logger   | Enable the Honeybadger Logger for handling errors outside of web requests | true |
-| exclude_envs | Environments that you want to disable Honeybadger notifications           | [:dev, :test] |
-| hostname     | Hostname of the system your application is running on                     | :inet.gethostname |
-| origin       | URL for the Honeybadger API                                               | "https://api.honeybadger.io" |
-| project_root | Directory root for where your application is running                      | System.cwd |
-| filter       | Module implementing `Honeybadger.Filter` to filter data before sending to Honeybadger.io         | `Honeybadger.Filter.Default`|
-| filter_keys  | A list of keywords (atoms) to filter.  Only valid if `filter` is `Honeybadger.Filter.Default` | [:password, :credit_card] |
-| filter_disable_url | If true, will remove the request url | false |
-| filter_disable_session | If true, will remove the request session | false |
-| filter_disable_params | If true, will remove the request params | false |
-| notice_filter       | Module implementing `Honeybadger.NoticeFilter`. If `nil`, no filtering is done. | `Honeybadger.NoticeFilter.Default`|
+| Name                     | Description                                                                                   | Default                                  |
+| ------------------------ | --------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `app`                    | Name of your app's OTP Application as an atom                                                 | `Mix.Project.config[:app]`               |
+| `api_key`                | Your application's Honeybadger API key                                                        | `System.get_env("HONEYBADGER_API_KEY"))` |
+| `environment_name`       | (required) The name of the environment your app is running in.                                | `nil`                                    |
+| `exclude_envs`           | Environments that you want to disable Honeybadger notifications                               | `[:dev, :test]`                          |
+| `hostname`               | Hostname of the system your application is running on                                         | `:inet.gethostname`                      |
+| `origin`                 | URL for the Honeybadger API                                                                   | `"https://api.honeybadger.io"`           |
+| `project_root`           | Directory root for where your application is running                                          | `System.cwd/0`                           |
+| `filter`                 | Module implementing `Honeybadger.Filter` to filter data before sending to Honeybadger.io      | `Honeybadger.Filter.Default`             |
+| `filter_keys`            | A list of keywords (atoms) to filter.  Only valid if `filter` is `Honeybadger.Filter.Default` | `[:password, :credit_card]`              |
+| `filter_args`            | If true, will remove function arguments in backtraces                                         | `true`                                   |
+| `filter_disable_url`     | If true, will remove the request url                                                          | `false`                                  |
+| `filter_disable_session` | If true, will remove the request session                                                      | `false`                                  |
+| `filter_disable_params`  | If true, will remove the request params                                                       | `false`                                  |
+| `notice_filter`          | Module implementing `Honeybadger.NoticeFilter`. If `nil`, no filtering is done.               | `Honeybadger.NoticeFilter.Default`       |
+| `use_logger`             | Enable the Honeybadger Logger for handling errors outside of web requests                     | `true`                                   |
 
 ## Public Interface
 

--- a/lib/honeybadger/backtrace.ex
+++ b/lib/honeybadger/backtrace.ex
@@ -3,35 +3,45 @@ defmodule Honeybadger.Backtrace do
   The Backtrace module contains functions for formatting system stacktraces.
   """
 
-  @app_context "app"
-  @all_context "all"
+  @inspect_opts charlists: :as_lists,
+                limit: 5,
+                printable_limit: 1024,
+                pretty: false
 
   @doc """
   Convert a system stacktrace into an API compatible backtrace.
 
-  The function expects a list of `:erlang.stack_item()` tuples.
+  When `filter_args` is disabled the arguments will be included. Arguments are
+  inspected and reported as binaries, regardless of the original format.
+
+      iex> stack_item = {:erlang, :funky, [{:ok, 123}], []}
+      ...> Honeybadger.Backtrace.from_stacktrace([stack_item])
+      [%{file: nil, number: nil, method: "funky/1", args: [], context: "all"}]
   """
+  @spec from_stacktrace(list(:erlang.stack_item())) :: list(map)
   def from_stacktrace(stacktrace) when is_list(stacktrace) do
     Enum.map(stacktrace, &format_line/1)
   end
 
   defp format_line({mod, fun, args, []}) do
-    format_line({mod, fun, args, [file: [], line: nil]})
+    format_line({mod, fun, args, [file: nil, line: nil]})
   end
 
   defp format_line({mod, fun, args, [file: file, line: line]}) do
     app = Honeybadger.get_env(:app)
     filter_args = Honeybadger.get_env(:filter_args)
 
-    %{file: format_file(file),
+    %{
+      file: format_file(file),
       method: format_method(fun, args),
       args: format_args(args, filter_args),
       number: line,
-      context: app_context(app, Application.get_application(mod))}
+      context: app_context(app, Application.get_application(mod))
+    }
   end
 
-  defp app_context(app, app) when not is_nil(app), do: @app_context
-  defp app_context(_app1, _app2), do: @all_context
+  defp app_context(app, app) when not is_nil(app), do: "app"
+  defp app_context(_app1, _app2), do: "all"
 
   defp format_file(""), do: nil
   defp format_file(file) when is_binary(file), do: file
@@ -40,14 +50,16 @@ defmodule Honeybadger.Backtrace do
   defp format_method(fun, args) when is_list(args) do
     format_method(fun, length(args))
   end
+
   defp format_method(fun, arity) when is_integer(arity) do
     "#{fun}/#{arity}"
   end
 
   defp format_args(args, false = _filter) when is_list(args) do
-    Enum.map(args, &inspect/1)
+    Enum.map(args, &Kernel.inspect(&1, @inspect_opts))
   end
-  defp format_args(_arity, _filter) do
+
+  defp format_args(_args_or_arity, _filter) do
     []
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule Honeybadger.Mixfile do
            notice_filter: Honeybadger.NoticeFilter.Default,
            filter: Honeybadger.Filter.Default,
            filter_keys: [:password, :credit_card],
+           filter_args: true,
            filter_disable_url: false,
            filter_disable_params: false,
            filter_disable_session: false],

--- a/test/honeybadger/backtrace_test.exs
+++ b/test/honeybadger/backtrace_test.exs
@@ -4,16 +4,49 @@ defmodule Honeybadger.BacktraceTest do
   alias Honeybadger.Backtrace
 
   test "converting a stacktrace to the format Honeybadger expects" do
-    stacktrace = [{:erlang, :some_func, [], []},
-      {Honeybadger, :notify, [],
+    stacktrace = [
+      {:erlang, :some_func, [{:ok, 123}], []},
+      {Honeybadger, :notify, [%RuntimeError{message: "error"}, %{a: 1}, [:a, :b]],
         [file: 'lib/honeybadger.ex', line: 38]},
-      {Honeybadger.Backtrace, :from_stacktrace, [],
-        [file: 'lib/honeybadger/backtrace.ex', line: 4]}]
+      {Honeybadger.Backtrace, :from_stacktrace, 1,
+        [file: 'lib/honeybadger/backtrace.ex', line: 4]}
+    ]
 
-    backtrace = Backtrace.from_stacktrace(stacktrace)
+    with_config([filter_args: false], fn ->
+      assert [entry_1, entry_2, entry_3] = Backtrace.from_stacktrace(stacktrace)
 
-    assert [%{file: nil, number: nil, method: "some_func", context: "all"},
-            %{file: "lib/honeybadger.ex", number: 38, method: "notify", context: "all"},
-            %{file: "lib/honeybadger/backtrace.ex", number: 4, method: "from_stacktrace", context: "all"}] == backtrace
+      assert entry_1 == %{
+        file: nil,
+        number: nil,
+        method: "some_func/1",
+        args: ["{:ok, 123}"],
+        context: "all"
+      }
+
+      assert entry_2 == %{
+        file: "lib/honeybadger.ex",
+        number: 38,
+        method: "notify/3",
+        args: ["%RuntimeError{message: \"error\"}", "%{a: 1}", "[:a, :b]"],
+        context: "all"
+      }
+
+      assert entry_3 == %{
+        file: "lib/honeybadger/backtrace.ex",
+        number: 4,
+        method: "from_stacktrace/1",
+        args: [],
+        context: "all"
+      }
+    end)
+  end
+
+  test "including args can be disabled" do
+    stacktrace = [{Honeybadger, :something, [1, 2, 3], []}]
+
+    with_config([filter_args: true], fn ->
+      assert [entry_1] = Backtrace.from_stacktrace(stacktrace)
+      assert match?(%{method: "something/3", args: []}, entry_1)
+    end)
   end
 end

--- a/test/honeybadger/backtrace_test.exs
+++ b/test/honeybadger/backtrace_test.exs
@@ -3,6 +3,8 @@ defmodule Honeybadger.BacktraceTest do
 
   alias Honeybadger.Backtrace
 
+  doctest Backtrace
+
   test "converting a stacktrace to the format Honeybadger expects" do
     stacktrace = [
       {:erlang, :some_func, [{:ok, 123}], []},

--- a/test/honeybadger/notice_test.exs
+++ b/test/honeybadger/notice_test.exs
@@ -46,9 +46,9 @@ defmodule Honeybadger.NoticeTest do
 
   test "error information", %{notice: %Notice{error: error}} do
     assert "RuntimeError" == error[:class]
-    assert "Oops"         == error[:message]
-    assert [:test]        == error[:tags]
-    assert [%{file: "lib/elixir/lib/kernel.ex", method: "+", number: 321, context: "all"}] == error[:backtrace]
+    assert "Oops" == error[:message]
+    assert [:test] == error[:tags]
+    assert [%{file: "lib/elixir/lib/kernel.ex", method: "+/1", args: [], number: 321, context: "all"}] == error[:backtrace]
   end
 
   test "request information", %{notice: %Notice{request: request}} do

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -47,11 +47,11 @@ defmodule HoneybadgerTest do
 
     traced = for %{"file" => file, "method" => fun} <- backtrace, do: {file, fun}
 
-    refute {"lib/process.ex", "info"} in traced
-    refute {"lib/honeybadger.ex", "backtrace"} in traced
-    refute {"lib/honeybadger.ex", "notify"} in traced
+    refute {"lib/process.ex", "info/1"} in traced
+    refute {"lib/honeybadger.ex", "backtrace/1"} in traced
+    refute {"lib/honeybadger.ex", "notify/3"} in traced
     assert {"test/honeybadger_test.exs",
-            "test sending a notice with exception stacktrace"} in traced
+            "test sending a notice with exception stacktrace/1"} in traced
   end
 
   test "fetching all application values" do


### PR DESCRIPTION
This enhances the backtrace to include function arity and arguments, if available. The arguments are inspected to ensure they can be serialized as JSON without any issues.

Argument inclusion is configured with `filter_args`, which defaults to `false`. Therefore by default arguments are included in a notice's backtrace. When arguments are filtered an empty list will be returned instead.

Also note, Poison can't encode tuples, structs, pids, refs, etc. so `inspect` is called on each argument. It may be preferable to be more selective with argument formatting, as a struct or list may be quite large. Any thoughts on this?

Addresses #78 