### PR TITLE
Allow handle_errors to be overridden

### DIFF
--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -9,22 +9,24 @@ defmodule Honeybadger.Plug do
       @phoenix Keyword.get(unquote(opts), :phoenix, :code.is_loaded(Phoenix))
 
       # Exceptions raised on non-existent Plug routes are ignored
-      defp handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}} = ex) do
+      def handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}} = ex) do
         nil
       end
 
       if @phoenix do
         # Exceptions raised on non-existent Phoenix routes are ignored
-        defp handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}} = ex) do
+        def handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}} = ex) do
           nil
         end
       end
 
-      defp handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
+      def handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
         metadata = %{plug_env: build_plug_env(conn, __MODULE__, @phoenix),
                      context: Honeybadger.context()}
         Honeybadger.notify(exception, metadata, stack)
       end
+
+      defoverridable [handle_errors: 2]
     end
   end
 


### PR DESCRIPTION
I've been looking for a way to skip reporting certain types of errors and I found it would be incredibly helpful if I could override the `handle_errors/2` function that `Honeybadger.Plug` generates. This change would allow me to do this:

```elixir
defmodule MyAppWeb.Router
  use MyAppWeb, :router
  use Honeybadger.Plug

  # Don't report UnauthenticatedError to Honeybadger
  def handle_errors(_conn, %{reason: MyAppWeb.UnauthenticatedError{}}), do: nil
  def handle_errors(conn, error_struct), do: super(conn, error_struct)
end
```
If there's a better way to do this, I'd be happy to hear it. I'd just prefer not to report all of my `UnauthenticatedError`s to Honeybadger.