### PR TITLE
Make plug dependency optional

### DIFF
--- a/lib/honeybadger/endpoint_data.ex
+++ b/lib/honeybadger/endpoint_data.ex
@@ -1,0 +1,23 @@
+if Code.ensure_loaded?(Plug) do
+  defmodule Honeybadger.EndpointData do
+    @moduledoc """
+    The HandlerData specification, used by any module that will report request
+    handling details.
+    """
+
+    @doc """
+    Extract the name of the handling component.
+
+    This could be a controller for a Phoenix application, or a module in a plug
+    pipeline.
+    """
+    @callback component(Plug.Conn.t(), module()) :: binary()
+
+    @doc """
+    Extract the named action for the handling component.
+
+    This could be a function like `create` or `update` in a Phoenix application.
+    """
+    @callback action(Plug.Conn.t()) :: binary()
+  end
+end

--- a/lib/honeybadger/phoenix_data.ex
+++ b/lib/honeybadger/phoenix_data.ex
@@ -1,25 +1,27 @@
-defmodule Honeybadger.PhoenixData do
-  alias Honeybadger.Utils
+if Code.ensure_loaded?(Phoenix) do
+  defmodule Honeybadger.PhoenixData do
+    alias Honeybadger.Utils
 
-  def component(conn, mod) do
-    # Phoenix.Controller.controller_module unfortunately raises
-    # when phoenix controller isn't available
-    case Utils.safe_exec(fn -> Phoenix.Controller.controller_module(conn) end) do
-      {:ok, controller} ->
-        Utils.module_to_string(controller)
-      {:error, _err} ->
-        Utils.module_to_string(mod)
+    def component(conn, mod) do
+      # Phoenix.Controller.controller_module unfortunately raises
+      # when phoenix controller isn't available
+      case Utils.safe_exec(fn -> Phoenix.Controller.controller_module(conn) end) do
+        {:ok, controller} ->
+          Utils.module_to_string(controller)
+        {:error, _err} ->
+          Utils.module_to_string(mod)
+      end
     end
-  end
 
-  def action(conn) do
-    # Phoenix.Controller.action_module unfortunately raises
-    # when phoenix controller isn't available
-    case Utils.safe_exec(fn -> Phoenix.Controller.action_name(conn) end) do
-      {:ok, action_name} ->
-        to_string(action_name)
-      {:error, _err} ->
-        ""
+    def action(conn) do
+      # Phoenix.Controller.action_module unfortunately raises
+      # when phoenix controller isn't available
+      case Utils.safe_exec(fn -> Phoenix.Controller.action_name(conn) end) do
+        {:ok, action_name} ->
+          to_string(action_name)
+        {:error, _err} ->
+          ""
+      end
     end
   end
 end

--- a/lib/honeybadger/phoenix_data.ex
+++ b/lib/honeybadger/phoenix_data.ex
@@ -1,10 +1,13 @@
 if Code.ensure_loaded?(Phoenix) do
   defmodule Honeybadger.PhoenixData do
-    alias Honeybadger.Utils
+    @moduledoc false
 
+    @behaviour Honeybadger.EndpointData
+
+    alias Honeybadger.{EndpointData, Utils}
+
+    @impl EndpointData
     def component(conn, mod) do
-      # Phoenix.Controller.controller_module unfortunately raises
-      # when phoenix controller isn't available
       case Utils.safe_exec(fn -> Phoenix.Controller.controller_module(conn) end) do
         {:ok, controller} ->
           Utils.module_to_string(controller)
@@ -13,9 +16,8 @@ if Code.ensure_loaded?(Phoenix) do
       end
     end
 
+    @impl EndpointData
     def action(conn) do
-      # Phoenix.Controller.action_module unfortunately raises
-      # when phoenix controller isn't available
       case Utils.safe_exec(fn -> Phoenix.Controller.action_name(conn) end) do
         {:ok, action_name} ->
           to_string(action_name)

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -1,88 +1,89 @@
-defmodule Honeybadger.Plug do
+if Code.ensure_loaded?(Plug) do
+  defmodule Honeybadger.Plug do
+    defmacro __using__(opts) do
+      quote do
+        use Plug.ErrorHandler
 
-  defmacro __using__(opts) do
-    quote do
-      import Honeybadger.Plug
-      require Honeybadger
-      use Plug.ErrorHandler
+        import Honeybadger.Plug
 
-      @phoenix Keyword.get(unquote(opts), :phoenix, :code.is_loaded(Phoenix))
+        @phoenix Keyword.get(unquote(opts), :phoenix, :code.is_loaded(Phoenix))
 
-      # Exceptions raised on non-existent Plug routes are ignored
-      def handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}} = ex) do
-        nil
-      end
-
-      if @phoenix do
-        # Exceptions raised on non-existent Phoenix routes are ignored
-        def handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}} = ex) do
+        # Exceptions raised on non-existent Plug routes are ignored
+        def handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}} = ex) do
           nil
         end
+
+        if @phoenix do
+          # Exceptions raised on non-existent Phoenix routes are ignored
+          def handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}} = ex) do
+            nil
+          end
+        end
+
+        def handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
+          metadata = %{plug_env: build_plug_env(conn, __MODULE__, @phoenix),
+                       context: Honeybadger.context()}
+          Honeybadger.notify(exception, metadata, stack)
+        end
+
+        defoverridable [handle_errors: 2]
+      end
+    end
+
+    def build_plug_env(%Plug.Conn{} = conn, mod, phoenix \\ false) do
+      {conn, session} = try do
+        Plug.Conn.fetch_session(conn)
+        session = conn.session
+        {conn, session}
+      rescue
+        _e in [ArgumentError, KeyError] ->
+          # just return conn and move on
+          {conn, %{}}
       end
 
-      def handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
-        metadata = %{plug_env: build_plug_env(conn, __MODULE__, @phoenix),
-                     context: Honeybadger.context()}
-        Honeybadger.notify(exception, metadata, stack)
+      conn = conn
+             |> Plug.Conn.fetch_cookies
+             |> Plug.Conn.fetch_query_params
+
+      conn_data_mod = if phoenix do
+        Honeybadger.PhoenixData
+      else
+        Honeybadger.PlugData
       end
 
-      defoverridable [handle_errors: 2]
-    end
-  end
-
-  def build_plug_env(%Plug.Conn{} = conn, mod, phoenix \\ false) do
-    {conn, session} = try do
-      Plug.Conn.fetch_session(conn)
-      session = conn.session
-      {conn, session}
-    rescue
-      _e in [ArgumentError, KeyError] ->
-        # just return conn and move on
-        {conn, %{}}
+      %{url: conn.request_path,
+        component: conn_data_mod.component(conn, mod),
+        action: conn_data_mod.action(conn),
+        params: conn.params,
+        session: session,
+        cgi_data: build_cgi_data(conn)}
     end
 
-    conn = conn
-           |> Plug.Conn.fetch_cookies
-           |> Plug.Conn.fetch_query_params
+    def build_cgi_data(%Plug.Conn{} = conn) do
+      rack_env_http_vars = Enum.reduce conn.req_headers, %{}, &header_to_rack_format/2
+      cgi_data = %{
+        "REQUEST_METHOD" => conn.method,
+        "PATH_INFO" => Enum.join(conn.path_info, "/"),
+        "QUERY_STRING" => conn.query_string,
+        "SCRIPT_NAME" => Enum.join(conn.script_name, "/"),
+        "REMOTE_ADDR" => get_remote_addr(conn.remote_ip),
+        "REMOTE_PORT" => get_remote_port(conn.peer),
+        "SERVER_ADDR" => "127.0.0.1",
+        "SERVER_NAME" => Honeybadger.get_env(:hostname),
+        "SERVER_PORT" => conn.port,
+        "CONTENT_LENGTH" => Plug.Conn.get_req_header(conn, "content-length"),
+        "ORIGINAL_FULLPATH" => conn.request_path
+      }
 
-    conn_data_mod = if phoenix do
-      Honeybadger.PhoenixData
-    else
-      Honeybadger.PlugData
+      Map.merge(rack_env_http_vars, cgi_data)
     end
 
-    %{url: conn.request_path,
-      component: conn_data_mod.component(conn, mod),
-      action: conn_data_mod.action(conn),
-      params: conn.params,
-      session: session,
-      cgi_data: build_cgi_data(conn)}
-  end
+    def get_remote_addr(addr), do: :inet.ntoa(addr) |> List.to_string
+    def get_remote_port({_, port}), do: port
 
-  def build_cgi_data(%Plug.Conn{} = conn) do
-    rack_env_http_vars = Enum.reduce conn.req_headers, %{}, &header_to_rack_format/2
-    cgi_data = %{
-      "REQUEST_METHOD" => conn.method,
-      "PATH_INFO" => Enum.join(conn.path_info, "/"),
-      "QUERY_STRING" => conn.query_string,
-      "SCRIPT_NAME" => Enum.join(conn.script_name, "/"),
-      "REMOTE_ADDR" => get_remote_addr(conn.remote_ip),
-      "REMOTE_PORT" => get_remote_port(conn.peer),
-      "SERVER_ADDR" => "127.0.0.1",
-      "SERVER_NAME" => Honeybadger.get_env(:hostname),
-      "SERVER_PORT" => conn.port,
-      "CONTENT_LENGTH" => Plug.Conn.get_req_header(conn, "content-length"),
-      "ORIGINAL_FULLPATH" => conn.request_path
-    }
-
-    Map.merge(rack_env_http_vars, cgi_data)
-  end
-
-  def get_remote_addr(addr), do: :inet.ntoa(addr) |> List.to_string
-  def get_remote_port({_, port}), do: port
-
-  def header_to_rack_format({header, value}, acc) do
-    header = "HTTP_" <> String.upcase(header) |> String.replace("-", "_")
-    Map.put(acc, header, value)
+    def header_to_rack_format({header, value}, acc) do
+      header = "HTTP_" <> String.upcase(header) |> String.replace("-", "_")
+      Map.put(acc, header, value)
+    end
   end
 end

--- a/lib/honeybadger/plug_data.ex
+++ b/lib/honeybadger/plug_data.ex
@@ -1,6 +1,8 @@
-defmodule Honeybadger.PlugData do
-  alias Honeybadger.Utils
+if Code.ensure_loaded?(Plug) do
+  defmodule Honeybadger.PlugData do
+    alias Honeybadger.Utils
 
-  def component(_conn, mod), do: Utils.module_to_string(mod)
-  def action(_conn), do: ""
+    def component(_conn, mod), do: Utils.module_to_string(mod)
+    def action(_conn), do: ""
+  end
 end

--- a/lib/honeybadger/plug_data.ex
+++ b/lib/honeybadger/plug_data.ex
@@ -1,8 +1,15 @@
 if Code.ensure_loaded?(Plug) do
   defmodule Honeybadger.PlugData do
-    alias Honeybadger.Utils
+    @moduledoc false
 
+    @behaviour Honeybadger.EndpointData
+
+    alias Honeybadger.{EndpointData, Utils}
+
+    @impl EndpointData
     def component(_conn, mod), do: Utils.module_to_string(mod)
+
+    @impl EndpointData
     def action(_conn), do: ""
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Honeybadger.Mixfile do
   defp deps do
     [{:hackney, "~> 1.1"},
      {:poison, "~> 2.0 or ~> 3.0"},
-     {:plug, ">= 1.0.0 and < 2.0.0"},
+     {:plug, ">= 1.0.0 and < 2.0.0", optional: true},
      {:phoenix, ">= 1.0.0 and < 2.0.0", optional: true},
 
      # Dev dependencies


### PR DESCRIPTION
This conditionally compiles Plug and Phoenix dependent modules, safely ignoring them when absent and preventing compiler warnings. Additionally, it adds a `Honeybadger.EndpointData` behaviour that is used by both `PlugData` and `PhoenixData`.

Closes #121