### PR TITLE
Allow handle_errors to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Include function arguments in notice backtraces. This is disabled by default,
   and can be enabled by setting `filter_args` to `false` in configuration.
 
+### Changed
+- Allow `handle_errors` from `Honeybadger.Plug` to be overridden
+
 ### Fixed
 - Safely convert binary `:environment_name` values to an atom. If the
   environment was specified via `{:system, "HONEYBADGER_ENV"}` and the

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -9,22 +9,24 @@ defmodule Honeybadger.Plug do
       @phoenix Keyword.get(unquote(opts), :phoenix, :code.is_loaded(Phoenix))
 
       # Exceptions raised on non-existent Plug routes are ignored
-      defp handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}} = ex) do
+      def handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}} = ex) do
         nil
       end
 
       if @phoenix do
         # Exceptions raised on non-existent Phoenix routes are ignored
-        defp handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}} = ex) do
+        def handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}} = ex) do
           nil
         end
       end
 
-      defp handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
+      def handle_errors(conn, %{kind: _kind, reason: exception, stack: stack}) do
         metadata = %{plug_env: build_plug_env(conn, __MODULE__, @phoenix),
                      context: Honeybadger.context()}
         Honeybadger.notify(exception, metadata, stack)
       end
+
+      defoverridable [handle_errors: 2]
     end
   end
 


### PR DESCRIPTION
This makes it possible to skip reporting more errors than just
Phoenix.Router.NoRouteError and non-existent plug routes.