### PR TITLE
Add Honeybadger.clear_context

### DIFF
--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -137,6 +137,7 @@ defmodule Honeybadger do
   end
 
   @context :honeybadger_context
+  @type context :: map
 
   @doc false
   def start(_type, _opts) do
@@ -209,13 +210,32 @@ defmodule Honeybadger do
     |> Client.send_notice()
   end
 
+  @doc """
+  Retrieves the context that will get sent to the Honeybadger API when/if an
+  exception occurs in the current process.
+  """
+  @spec context :: context
   def context do
     (Process.get(@context) || %{}) |> Enum.into(Map.new)
   end
 
-  def context(keyword_or_map) do
-    Process.put(@context, Map.merge(context(), Enum.into(keyword_or_map, %{})))
+  @doc """
+  Merges `additional_context` into the the context that will get sent to the
+  Honeybadger API when/if an exception occurs in the current process.
+  """
+  @spec context(map | keyword) :: context
+  def context(additional_context) do
+    Process.put(@context, Map.merge(context(), Enum.into(additional_context, %{})))
     context()
+  end
+
+  @doc """
+  Clears the context that will get sent to the Honeybadger API when/if an
+  exception occurs in the current process.
+  """
+  @spec clear_context :: :ok
+  def clear_context do
+    Process.delete(@context)
   end
 
   @doc """

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -216,7 +216,7 @@ defmodule Honeybadger do
   """
   @spec context :: context
   def context do
-    (Process.get(@context) || %{}) |> Enum.into(Map.new)
+    Process.get(@context, %{})
   end
 
   @doc """
@@ -224,7 +224,7 @@ defmodule Honeybadger do
   Honeybadger API when/if an exception occurs in the current process.
   """
   @spec context(map | keyword) :: context
-  def context(additional_context) do
+  def context(additional_context) when is_map(additional_context) or is_list(additional_context) do
     Process.put(@context, Map.merge(context(), Enum.into(additional_context, %{})))
     context()
   end

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -158,4 +158,18 @@ defmodule HoneybadgerTest do
     Honeybadger.clear_context()
     assert %{} == Honeybadger.context()
   end
+
+  test "setting context with invalid data type" do
+    assert_raise FunctionClauseError, fn ->
+      Honeybadger.context(nil)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Honeybadger.context(true)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      Honeybadger.context(3)
+    end
+  end
 end

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -146,7 +146,7 @@ defmodule HoneybadgerTest do
     assert Honeybadger.get_env(:unused) == nil
   end
 
-  test "getting and setting the context" do
+  test "getting, setting and clearing the context" do
     assert %{} == Honeybadger.context()
 
     Honeybadger.context(user_id: 1)
@@ -154,5 +154,8 @@ defmodule HoneybadgerTest do
 
     Honeybadger.context(%{user_id: 2})
     assert %{user_id: 2} == Honeybadger.context()
+
+    Honeybadger.clear_context()
+    assert %{} == Honeybadger.context()
   end
 end


### PR DESCRIPTION
I am trying to use `Honeybadger.context/1` inside a [Honeydew](https://github.com/koudelka/honeydew) worker, which is a long-lived process that handles multiple jobs. Because these workers are long-lived, when a worker starts a new job the context from the previous job is carried over until the new job overwrites it.

This adds a `Honeybadger.clear_context/0` function which could be called at any time to completely reset the context for the current process. I can't think of any additional issues this would cause.

I also added docs and typespecs for `context/0` and `context/1`.