### PR TITLE
Use lazy logging in the client module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Use lazy logging within `Honeybadger.Client`, this allows compile time purging
+  when the log level is set higher.
 
 ## [v0.8.0] - 2018-01-17
 ### Added


### PR DESCRIPTION
This allows the log message to be ignored when the log-level is beyond the custom threshold. For example, successful requests log the API success with a call to `Logger.debug`, which probably won't be enabled in production.

There is a little bit of other cleanup in here as well. I've annotated `GenServer` callbacks and added some type specs, but most of the changes are from running `mix format` on the module.