### PR TITLE
Add Honeybadger to Dev warning

### DIFF
--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -172,7 +172,7 @@ defmodule Honeybadger.Client do
 
   defp warn_in_dev_mode(%{enabled: false}) do
     Logger.warn(fn ->
-      "Development mode is enabled. Data will not be reported until you deploy your app."
+      "[Honeybadger] Development mode is enabled. Data will not be reported until you deploy your app."
     end)
   end
 

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -35,7 +35,7 @@ defmodule HoneybadgerTest do
       end)
 
     assert logged =~
-             ~s|Development mode is enabled. Data will not be reported until you deploy your app.|
+             ~s|[Honeybadger] Development mode is enabled. Data will not be reported until you deploy your app.|
   end
 
   test "should not show warning if env is complete" do


### PR DESCRIPTION
This adds the `[Honeybadger]` tag to the development warning. 

When using Honeybadger in an application it may be unclear where this warning is coming from.