### PR TITLE
Fix issue where hackney pool silently ceases to function.

### DIFF
--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -121,10 +121,12 @@ defmodule Honeybadger.Client do
 
     case :hackney.post(state.url, state.headers, payload, opts) do
       {:ok, code, _headers, ref} when code >= 200 and code <= 399 ->
-        Logger.debug(fn -> "[Honeybadger] API success: #{inspect(body_from_ref(ref))}" end)
+        body = body_from_ref(ref)
+        Logger.debug(fn -> "[Honeybadger] API success: #{inspect(body)}" end)
 
       {:ok, code, _headers, ref} when code >= 400 and code <= 504 ->
-        Logger.error(fn -> "[Honeybadger] API failure: #{inspect(body_from_ref(ref))}" end)
+        body = body_from_ref(ref)
+        Logger.error(fn -> "[Honeybadger] API failure: #{inspect(body)}" end)
 
       {:error, reason} ->
         Logger.error(fn -> "[Honeybadger] connection error: #{inspect(reason)}" end)


### PR DESCRIPTION
A few days back, we upgraded our honeybadger dependency and deployed to production. Soon afterwards, we discovered that all the bugs in our app had magically been solved and that we were the most amazing developers on the planet.

Err, well, not quite. It just looks like there was a bug preventing our failings from being reported to Honeybadger. 

A symptom we found was that the hackney pool was filling up with clients, and after `@max_connections` number of errors were reported, it went silent. We discovered that this happens when you don't read the response bodies from your requests.

We have our Logger's `:compile_time_purge_level` set to `:info` in production, and as such, the lines in `Honeybadger.Client` that read response bodies are entirely stripped out of the AST. Additionally, since they're thunked, I believe they won't be executed if the log level is above `:debug` even without compile-time purge.

The docs recommend against doing cleanup-like activities within log statements themselves: https://hexdocs.pm/logger/Logger.html#module-application-configuration

This patch changes the client to always read response bodies. I'll leave the tests up to you folks, should you feel they're necessary.

(Thanks to @aaronrenner for banging skulls with me trying to figure this one out.)

re: https://github.com/benoitc/hackney/issues/462