### PR TITLE
Remove use of System.stracktrace/0 outside of try

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,6 @@ matrix:
       elixir: 1.5
     - otp_release: 20.1
       elixir: 1.6
-            
+    - otp_release: 21.0
+      elixir: 1.7
 sudo: false

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -204,7 +204,7 @@ defmodule Honeybadger do
       :ok
   """
   @spec notify(Notice.noticeable(), Map.t(), list) :: :ok
-  def notify(exception, metadata \\ %{}, stacktrace \\ nil) do
+  def notify(exception, metadata \\ %{}, stacktrace \\ []) do
     exception
     |> Notice.new(contextual_metadata(metadata), backtrace(stacktrace))
     |> Client.send_notice()
@@ -308,18 +308,14 @@ defmodule Honeybadger do
     config
   end
 
-  defp backtrace([]) do
-    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
-
-    backtrace(stacktrace)
-  end
-
-  defp backtrace(stacktrace) when is_list(stacktrace) do
+  defp backtrace([_stack_item | _stack_items] = stacktrace) do
     Backtrace.from_stacktrace(stacktrace)
   end
 
   defp backtrace(_stacktrace) do
-    backtrace(System.stacktrace())
+    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+
+    backtrace(stacktrace)
   end
 
   defp contextual_metadata(%{context: _} = metadata) do

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -81,7 +81,7 @@ defmodule HoneybadgerTest do
       raise RuntimeError
     rescue
       exception ->
-        :ok = Honeybadger.notify(exception)
+        :ok = Honeybadger.notify(exception, %{}, System.stacktrace())
     end
 
     assert_receive {:api_request, %{"error" => %{"backtrace" => backtrace}}}
@@ -91,7 +91,6 @@ defmodule HoneybadgerTest do
     refute {"lib/process.ex", "info/1"} in traced
     refute {"lib/honeybadger.ex", "backtrace/1"} in traced
     refute {"lib/honeybadger.ex", "notify/3"} in traced
-
     assert {"test/honeybadger_test.exs", "test sending a notice with exception stacktrace/1"} in traced
   end
 


### PR DESCRIPTION
This adds tests for Erlang 21.0 and Elixir 1.7.0 to the build matrix. One of the big changes is the introduction of `__STACKTRACE__` and the deprecation of `System.stacktrace/0`.

To prevent compile time warnings moving forward we are removing the fallback `System.stacktrace/0` call inside of `honeybadger.ex`. The call was made outside of a `try/catch` and wasn't guaranteed to return the correct stacktrace anyhow.