### PR TITLE
Guard against nil returns from Process.info/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Prevent crashes reporting `:badmatch` when fetching the current stacktrace
+  from a dead process.
 
 ## [v0.10.2] - 2018-07-02
 ### Fixed

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -313,9 +313,10 @@ defmodule Honeybadger do
   end
 
   defp backtrace(_stacktrace) do
-    {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
-
-    backtrace(stacktrace)
+    case Process.info(self(), :current_stacktrace) do
+      {:current_stacktrace, stacktrace} -> Backtrace.from_stacktrace(stacktrace)
+      _unknown -> []
+    end
   end
 
   defp contextual_metadata(%{context: _} = metadata) do


### PR DESCRIPTION
When a process is no longer alive any calls to `Process.info/2` will return `nil` instead of the expected tuple. Inside of the fallback clause for `backtrace/1` we always matched on a stacktrace tuple and didn't account for the possibility of a `nil` return. This change makes the backtrace generation safer by using a `case` instead of a fixed match.

During my experimentation I wasn't able to call `backtrace/1` from a process and have the process die before `Process.info/2` was called. The case clause is defensive and should cover the known failure case, but it seems to be untestable.

Closes #172