### PR TITLE
Migrate to Elixir 1.7+ Logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,10 @@
 language: elixir
 sudo: false
 elixir:
-  - 1.4
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
 otp_release:
-  - 20.3
   - 21.2
-matrix:
-  exclude:
-    - otp_release: 21.2
-      elixir: 1.4
-    - otp_release: 21.2
-      elixir: 1.5
-    - otp_release: 21.2
-      elixir: 1.6
 env:
   - MIX_ENV=test
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,23 @@
 # Changelog
+
 All notable changes to this project will be documented in this file. See [Keep a
 CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Switch from Erlang's `:error_logger` to an Elixir 1.7 and Erlang/OTP 21+
+  `Logger` backend. This provides more consistent error reporting and enhanced
+  integration with Logger metadata.
+- Stop automatically extracting stacktraces for calls to `Honeybadger.notice/3`.
+  The generated stacktrace was unreliably and frequently listed the Honeybadger
+  reporter's internals, rather than application code. Manual calls to `notice/3`
+  should happen within a `rescue/catch` block and use the `__STACKTRACE__`
+  macro.
+
 ### Added
-- Use `Logger.metadata` to enrich the Honeybadger context for all notices
+- Use `Logger.metadata` as the basis for Honeybadger context in all logger
+  generated notices
 
 ## [v0.10.3] - 2018-07-02
 ### Fixed
@@ -34,11 +46,11 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Update dependenices.
 
 ### Fixed
-- Fix crashes caused by JSON encoding error, we now log an error when there is a
+
   JSON encoding error.
 - Send notifications even when the stacktrace isn't a list. Errors reported from
   the error logger can occasionally have a malformed stacktrace, which would
-  raise another exception prevent the notification from being sent.
+  raise another exception and prevent the notification from being sent.
 
 ## [v0.9.0] - 2018-03-21
 ### Changed

--- a/lib/honeybadger/backtrace.ex
+++ b/lib/honeybadger/backtrace.ex
@@ -3,7 +3,7 @@ defmodule Honeybadger.Backtrace do
   The Backtrace module contains functions for formatting system stacktraces.
   """
 
-  @type location :: {:file, string()} | {:line, pos_integer()}
+  @type location :: {:file, binary()} | {:line, pos_integer()}
   @type stack_item :: {module(), atom(), arity() | [term()], [location()]}
 
   @inspect_opts charlists: :as_lists,

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -3,82 +3,66 @@ defmodule Honeybadger.Logger do
 
   @behaviour :gen_event
 
-  require Logger
-
-  alias Honeybadger.Utils
-
-  def init(args) do
-    {:ok, args}
+  @impl true
+  def init(__MODULE__) do
+    init({__MODULE__, []})
   end
 
-  ## Callbacks
+  def init({__MODULE__, opts}) when is_list(opts) do
+    level = Keyword.get(opts, :level)
 
+    {:ok, %{level: level}}
+  end
+
+  @impl true
+  def handle_call({:configure, _options}, state) do
+    {:ok, :ok, state}
+  end
+
+  @impl true
   def handle_event({_type, gl, _msg}, state) when node(gl) != node() do
     {:ok, state}
   end
 
-  def handle_event(event, state) do
-    handle_error(event)
+  def handle_event({:error, _gl, {Logger, _msg, _ts, metadata}}, state) do
+    case Keyword.get(metadata, :crash_reason) do
+      {reason, stacktrace} ->
+        Honeybadger.notify(reason, extract_context(metadata), stacktrace)
+
+      reason when is_atom(reason) and not is_nil(reason) ->
+        Honeybadger.notify(reason, extract_context(metadata), [])
+
+      _ ->
+        :ok
+    end
 
     {:ok, state}
   end
 
-  def handle_call({:configure, new_keys}, _state) do
-    {:ok, :ok, new_keys}
+  def handle_event(_, state) do
+    {:ok, state}
   end
 
-  def handle_call(request, _state) do
-    exit({:bad_call, request})
-  end
-
+  @impl true
   def handle_info(_msg, state) do
     {:ok, state}
   end
 
+  @impl true
   def code_change(_old_vsn, state, _extra) do
     {:ok, state}
   end
 
+  @impl true
   def terminate(_reason, _state) do
     :ok
   end
 
   ## Helpers
 
-  defp handle_error({:error_report, _gl, {_pid, _type, [message | _]}}) when is_list(message) do
-    try do
-      context =
-        message
-        |> get_in([:dictionary, :honeybadger_context])
-        |> merge_metadata(get_in(message, [:dictionary, :logger_metadata]))
-
-      case message[:error_info] do
-        {_kind, {exception, stacktrace}, _stack} ->
-          Honeybadger.notify(exception, context, stacktrace)
-
-        {_kind, exception, stacktrace} ->
-          Honeybadger.notify(exception, context, stacktrace)
-      end
-    rescue
-      exception ->
-        Logger.warn(fn ->
-          error_type = Utils.module_to_string(exception.__struct__)
-          reason = Exception.message(exception)
-
-          "Unable to notify Honeybadger! #{error_type}: #{reason}"
-        end)
-    end
-  end
-
-  defp handle_error(_event) do
-    :ok
-  end
-
-  defp merge_metadata(%{} = context, {_, metadata}) when is_list(metadata) do
+  defp extract_context(metadata) do
     metadata
+    |> Keyword.drop([:ancestors, :callers, :crash_reason, :pid])
     |> Map.new()
-    |> Map.merge(context)
   end
-
-  defp merge_metadata(context, _md), do: context
 end

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -48,8 +48,7 @@ defmodule Honeybadger.Notice do
   end
 
   def new(%{class: class, message: message}, metadata, backtrace) do
-    %{class: class, message: message, backtrace: backtrace}
-    |> create(metadata)
+    create(%{class: class, message: message, backtrace: backtrace}, metadata)
   end
 
   def new(exception, metadata, backtrace) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Honeybadger.Mixfile do
   def project do
     [
       app: :honeybadger,
-      version: "0.10.3",
-      elixir: "~> 1.4",
+      version: "0.11.0",
+      elixir: "~> 1.7",
       consolidate_protocols: Mix.env() != :test,
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/honeybadger/logger_test.exs
+++ b/test/honeybadger/logger_test.exs
@@ -3,20 +3,6 @@ defmodule Honeybadger.LoggerTest do
 
   require Logger
 
-  defmodule ErrorServer do
-    use GenServer
-
-    def start do
-      GenServer.start(__MODULE__, [])
-    end
-
-    def init(_), do: {:ok, []}
-
-    def handle_cast(:fail, _state) do
-      raise RuntimeError, "Crashing"
-    end
-  end
-
   setup do
     {:ok, _} = Honeybadger.API.start(self())
 
@@ -25,27 +11,114 @@ defmodule Honeybadger.LoggerTest do
     on_exit(&Honeybadger.API.stop/0)
   end
 
-  test "logging a crash" do
-    Task.start(fn -> raise RuntimeError, "Oops" end)
+  test "GenServer terminating with an error" do
+    defmodule MyGenServer do
+      use GenServer
 
-    assert_receive {:api_request, notification}
+      def start_link(_opts) do
+        GenServer.start(__MODULE__, [meta: :data], name: Elixir.MyGenServer)
+      end
 
-    assert %{"error" => %{"class" => "RuntimeError"}} = notification
+      def init(opts), do: {:ok, opts}
+
+      def handle_cast(:raise_error, state) do
+        Map.fetch!(%{}, :bad_key)
+
+        {:noreply, state}
+      end
+    end
+
+    {:ok, pid} = start_supervised(MyGenServer)
+
+    GenServer.cast(pid, :raise_error)
+
+    assert_receive {:api_request, %{"error" => error, "request" => request}}
+
+    assert error["class"] == "KeyError"
+
+    assert request["context"]["registered_name"] == "Elixir.MyGenServer"
+    assert request["context"]["last_message"] =~ "$gen_cast"
+    assert request["context"]["state"] == "[meta: :data]"
   end
 
-  test "includes logger metadata as context" do
+  test "GenEvent terminating with an error" do
+    defmodule MyEventHandler do
+      @behaviour :gen_event
+
+      def init(state), do: {:ok, state}
+      def terminate(_reason, _state), do: :ok
+      def code_change(_old_vsn, state, _extra), do: {:ok, state}
+      def handle_call(_request, state), do: {:ok, :ok, state}
+      def handle_info(_message, state), do: {:ok, state}
+
+      def handle_event(:raise_error, state) do
+        raise "Oops"
+
+        {:ok, state}
+      end
+    end
+
+    {:ok, manager} = :gen_event.start()
+    :ok = :gen_event.add_handler(manager, MyEventHandler, {})
+
+    :gen_event.notify(manager, :raise_error)
+
+    assert_receive {:api_request, %{"error" => error, "request" => request}}
+
+    assert error["class"] == "RuntimeError"
+
+    assert request["context"]["name"] == "Honeybadger.LoggerTest.MyEventHandler"
+    assert request["context"]["last_message"] =~ ":raise_error"
+    assert request["context"]["state"] == "{}"
+  end
+
+  test "process raising an error" do
+    pid = spawn(fn -> raise "Oops" end)
+
+    assert_receive {:api_request, %{"error" => error, "request" => request}}
+
+    assert error["class"] == "RuntimeError"
+
+    assert request["context"]["name"] == inspect(pid)
+  end
+
+  test "task with anonymous function raising an error" do
+    Task.start(fn -> raise "Oops" end)
+
+    assert_receive {:api_request, %{"error" => error, "request" => request}}
+
+    assert error["class"] == "RuntimeError"
+    assert error["message"] == "Oops"
+
+    assert request["context"]["function"] =~ ~r/\A#Function<.* in Honeybadger\.LoggerTest/
+    assert request["context"]["args"] == "[]"
+  end
+
+  test "task with mfa raising an error" do
+    defmodule MyModule do
+      def raise_error(message), do: raise(message)
+    end
+
+    Task.start(MyModule, :raise_error, ["my message"])
+
+    assert_receive {:api_request, %{"error" => error, "request" => request}}
+
+    assert request["context"]["function"] =~ "&Honeybadger.LoggerTest.MyModule.raise_error/1"
+    assert request["context"]["args"] == ~s(["my message"])
+  end
+
+  test "includes additional logger metadata as context" do
     Task.start(fn ->
       Logger.metadata(age: 2, name: "Danny", user_id: 3)
 
-      raise RuntimeError, "Oops"
+      raise "Oops"
     end)
 
-    assert_receive {:api_request, notification}
+    assert_receive {:api_request, %{"request" => request}}
 
-    %{"error" => error, "request" => %{"context" => context}} = notification
-
-    assert %{"class" => "RuntimeError"} = error
-    assert %{"age" => 2, "name" => "Danny", "user_id" => 3} = context
+    assert request["context"]["age"] == 2
+    assert request["context"]["name"] == "Danny"
+    assert request["context"]["user_id"] == 3
   end
 
   test "log levels lower than :error are ignored" do
@@ -54,22 +127,5 @@ defmodule Honeybadger.LoggerTest do
     Logger.info(fn -> "This is not a real error" end)
 
     refute_receive {:api_request, _}
-  end
-
-  # GenServer terminating with an Elixir error
-  # GenServer terminating with an Erlang error
-  # GenServer terminating because of an exit
-  # GenServer stopping
-  # GenEvent terminating
-  # Process raising an error
-  # Task with anonymous function raising an error
-  # Task with mfa raising an error
-
-  test "logging exceptions from GenServers" do
-    {:ok, pid} = ErrorServer.start()
-
-    GenServer.cast(pid, :fail)
-
-    assert_receive {:api_request, %{"error" => %{"class" => "RuntimeError"}}}
   end
 end

--- a/test/honeybadger/notice_test.exs
+++ b/test/honeybadger/notice_test.exs
@@ -35,7 +35,7 @@ defmodule Honeybadger.NoticeTest do
 
     assert :test == server[:environment_name]
     assert hostname == server[:hostname]
-    assert System.cwd() == server[:project_root]
+    assert File.cwd!() == server[:project_root]
   end
 
   test "server information config", _ do

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -151,16 +151,14 @@ defmodule HoneybadgerTest do
   end
 
   test "getting, setting and clearing the context" do
-    assert %{} == Honeybadger.context()
+    assert Honeybadger.context() == %{}
 
-    Honeybadger.context(user_id: 1)
-    assert %{user_id: 1} == Honeybadger.context()
+    assert Honeybadger.context(user_id: 1) == %{user_id: 1}
+    assert Honeybadger.context(%{user_id: 2}) == %{user_id: 2}
+    assert Honeybadger.context() == %{user_id: 2}
 
-    Honeybadger.context(%{user_id: 2})
-    assert %{user_id: 2} == Honeybadger.context()
-
-    Honeybadger.clear_context()
-    assert %{} == Honeybadger.context()
+    :ok = Honeybadger.clear_context()
+    assert Honeybadger.context() == %{}
   end
 
   test "setting context with invalid data type" do

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -81,7 +81,7 @@ defmodule HoneybadgerTest do
       raise RuntimeError
     rescue
       exception ->
-        :ok = Honeybadger.notify(exception, %{}, System.stacktrace())
+        :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
     end
 
     assert_receive {:api_request, %{"error" => %{"backtrace" => backtrace}}}


### PR DESCRIPTION
This PR is a multi-pronged attempt to provide richer context, more consistent reporting and eliminate inconsistent stacktraces that have plagued so many of us (see #200 for an example).

* [SASL Logging](http://erlang.org/doc/apps/sasl/error_logging.html) — This switches from using the deprecated `:error_logger` to the enhanced `Logger` backend provided since Elixir 1.7+ 
* [Logger Backend](https://hexdocs.pm/logger/Logger.html#module-metadata) — Context now uses the Logger metadata for storage. This is because the new logger messages/meta doesn't include a `:dictionary` key to extract the metadata from, and the process isn't guaranteed to be alive so `:process_info` isn't reliable either. As a bonus, we get very consistent metadata formatting.
* [\_\_STACKTRACE\_\_](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#__STACKTRACE__/0) — Calling `notify/3` without a stacktrace (or with `[]`) no longer pulls `:current_stacktrace` from the current process. This directly resulted in incorrect backtraces that made error reports hard to work with. Calling `System.stacktrace/0` is deprecated and [get_stacktrace](http://erlang.org/doc/man/erlang.html#get_stacktrace-0) will be removed from future OTP versions.
* Enhanced context for `GenServer`, `Task`, `gen_event`, and `spawn` reporting. By parsing the message format we now get `last_message` and `state` for `Gen*` reports, and `function/args` for `Task` reports. The `Logger` tests have been modified to cover these additional cases.

There aren't any breaking API changes, but the package now requires Elixir 1.7+ and OTP 21+. The project's elixir version and build matrix have been modified accordingly, but we'll need some additional messaging and an upgrade guide for people upgrading.
