### PR TITLE
Add note about OS env for config options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ config :honeybadger,
   environment_name: :prod
 ```
 
+If you'd rather read, eg., `environment_name` from the OS environment, you can do like this:
+
+```elixir
+config :honeybadger,
+  environment_name: {:system, "HONEYBADGER_ENV"}
+```
+
+_NOTE: This works only for the string options, and `environment_name`._
+
 Here are all of the options you can pass in the keyword list:
 
 | Name                     | Description                                                                                   | Default                                  |


### PR DESCRIPTION
I had to dig around in the source code a bit before realizing that it *is* indeed possible to set config options from OS environment, so I thought it might be worth mentioning in the README.