### PR TITLE
Automatically call Exception.blame/3 for enhanced errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Added `:revision` configuration option
+- Automatically call `Exception.blame/3` to record additional information in the exception
 
 ## [v0.11.0] - 2019-02-28
 When upgrading to v0.11, users should be aware of a few important changes:

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -203,6 +203,7 @@ defmodule Honeybadger do
   """
   @spec notify(Notice.noticeable(), map(), list()) :: :ok
   def notify(exception, metadata \\ %{}, stacktrace \\ []) do
+    {exception, _} = Exception.blame(:error, exception, stacktrace)
     backtrace = Backtrace.from_stacktrace(stacktrace)
 
     exception


### PR DESCRIPTION
It can convert an error like this:

no function clause matching in Messages.handle_message_created/2
into:

no function clause matching in Messages.build_notifications/3

The following arguments were given to Messages.build_notifications/3:

    # 1
    %Chat.Message{__meta__: #Ecto.Schema.Metadata<:loaded, "messages">, ...snip large struct value}

    # 2
    nil

    # 3
    nil

Attempted function clauses (showing 3 out of 3):

    def build_notifications(message, thread, -%Messages.MessageContainer.MessageContainerImpl{container_id: post_id}-)
    def build_notifications(%{id: message_id}, _thread, -%Communities.Post{message_id: message_id}-)
    def build_notifications(message, thread, -%Communities.Post{} = post-)

Fixes #211