### PR TITLE
Include Erlang/OTP 22 in the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ elixir:
   - 1.8
 otp_release:
   - 21.2
+  - 22.0
 env:
   - MIX_ENV=test
 script:


### PR DESCRIPTION
Getting this in before we release 0.12.