### PR TITLE
Normalize string errors before exception blame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+#### Fixed
+- Call `Exception.blame/3` after normalizing string errors, which prevents reporint all string messages as Erlang errors. (#225)
 
 ## [v0.12.0] - 2019-05-30
 ### Added

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -125,7 +125,7 @@ defmodule Honeybadger do
 
   use Application
 
-  alias Honeybadger.{Backtrace, Client, Notice}
+  alias Honeybadger.{Client, Notice}
 
   defmodule MissingEnvironmentNameError do
     defexception message: """
@@ -203,11 +203,8 @@ defmodule Honeybadger do
   """
   @spec notify(Notice.noticeable(), map(), list()) :: :ok
   def notify(exception, metadata \\ %{}, stacktrace \\ []) do
-    {exception, _} = Exception.blame(:error, exception, stacktrace)
-    backtrace = Backtrace.from_stacktrace(stacktrace)
-
     exception
-    |> Notice.new(contextual_metadata(metadata), backtrace)
+    |> Notice.new(contextual_metadata(metadata), stacktrace)
     |> Client.send_notice()
   end
 

--- a/test/honeybadger/backtrace_test.exs
+++ b/test/honeybadger/backtrace_test.exs
@@ -3,8 +3,6 @@ defmodule Honeybadger.BacktraceTest do
 
   alias Honeybadger.Backtrace
 
-  doctest Backtrace
-
   test "converting a stacktrace to the format Honeybadger expects" do
     stacktrace = [
       {:erlang, :some_func, [{:ok, 123}], []},

--- a/test/honeybadger/json_test.exs
+++ b/test/honeybadger/json_test.exs
@@ -7,10 +7,16 @@ defmodule Honeybadger.JSONTest do
     defstruct [:ip]
   end
 
-  describe "encode" do
+  describe "encode/1" do
     test "encodes notice" do
       notice = Notice.new(%RuntimeError{message: "oops"}, %{}, [])
-      assert JSON.encode(notice) == Jason.encode(notice)
+
+      assert {:ok, encoded} = JSON.encode(notice)
+
+      assert encoded =~ ~s|"notifier"|
+      assert encoded =~ ~s|"server"|
+      assert encoded =~ ~s|"error"|
+      assert encoded =~ ~s|"request"|
     end
 
     test "encodes notice when context has structs" do

--- a/test/honeybadger/notice_test.exs
+++ b/test/honeybadger/notice_test.exs
@@ -3,7 +3,7 @@ defmodule Honeybadger.NoticeTest do
 
   doctest Honeybadger.Notice
 
-  alias Honeybadger.{Backtrace, Notice}
+  alias Honeybadger.Notice
 
   setup do
     exception = %RuntimeError{message: "Oops"}
@@ -17,9 +17,8 @@ defmodule Honeybadger.NoticeTest do
 
     metadata = %{plug_env: plug_env, tags: [:test], context: %{user_id: 1, account_id: 1}}
     stack = [{Kernel, :+, [1], [file: 'lib/elixir/lib/kernel.ex', line: 321]}]
-    backtrace = Backtrace.from_stacktrace(stack)
 
-    notice = Notice.new(exception, metadata, backtrace)
+    notice = Notice.new(exception, metadata, stack)
 
     {:ok, [notice: notice]}
   end
@@ -75,7 +74,8 @@ defmodule Honeybadger.NoticeTest do
   end
 
   test "erlang error normalization", _ do
-    %{error: %{class: class}} = Notice.new(:badarg, %{}, nil)
+    %{error: %{class: class}} = Notice.new(:badarg, %{}, [])
+
     assert class == "ArgumentError"
   end
 
@@ -87,7 +87,7 @@ defmodule Honeybadger.NoticeTest do
     refute get_in(notice.request, [:params, :password])
   end
 
-  test "User implemented Filter works" do
+  test "user implemented filter works" do
     defmodule TestFilter do
       use Honeybadger.Filter.Mixin
 
@@ -196,7 +196,7 @@ defmodule Honeybadger.NoticeTest do
     end)
   end
 
-  test "Setting notice_filter to nil disables filtering" do
+  test "setting notice_filter to nil disables filtering" do
     with_config([notice_filter: nil], fn ->
       notice = filterable_notice()
 


### PR DESCRIPTION
We need to convert string based errors to an exception before calling `Exception.blame/3` on exceptions. Calling `blame` requires a proper stacktrace to work. However, normalization took place inside the `Notice` module which was only passed the Honeybadger specific backtrace.

In order to centralize normalization and improve the blame behavior all of the conversion now happens in `Notice.new/3`. As part of this effort the typespecs, guards and function signatures have been improved.

The `Backtrace` and `Notice` modules are also no longer public. There wasn't any reason for developers to call them directly and the small documentation that was there wasn't especially helpful.

Closes #225

@joshuap Nothing critical here, but it seems like something we should get out sooner than later.