### PR TITLE
Adjust README to modern versions of Elixir (and Honeybadger ;)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,20 @@ Elixir Plug, Logger and client for the :zap: [Honeybadger error notifier](https:
 
 Prerequisites: minimum of Elixir 1.0 and Erlang 18.0
 
-Add the Honeybadger package to `deps/0` and `application/0` in your
+Add the Honeybadger package to `deps/0` in your
 application's `mix.exs` file and run `mix do deps.get, deps.compile`
+
+```elixir
+defp deps do
+  [{:honeybadger, "~> 0.7"}]
+end
+```
+
+For Elixir versions _before_ 1.6, also add `:honeybadger` to `:applications`:
 
 ```elixir
 defp application do
  [applications: [:honeybadger, :logger]]
-end
-
-defp deps do
-  [{:honeybadger, "~> 0.7"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ application's `mix.exs` file and run `mix do deps.get, deps.compile`
 
 ```elixir
 defp deps do
-  [{:honeybadger, "~> 0.7"}]
+  [{:honeybadger, "~> 0.12"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,6 @@ defp deps do
 end
 ```
 
-For Elixir versions _before_ 1.6, also add `:honeybadger` to `:applications`:
-
-```elixir
-defp application do
- [applications: [:honeybadger, :logger]]
-end
-```
-
 ### 2. Set your API key and environment name
 
 By default the environment variable `HONEYBADGER_API_KEY` will be used to find


### PR DESCRIPTION
Adjust the README so that newbies aren't confused. Moves the older Elixir version instructions to a separate paragraph.

Update the Honeybadger version in the setup instructions too.