### PR TITLE
Sanitize invalid binaries when encoding JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Safely sanitize invalid binaries when encoding JSON for notices.
 
 ## [v0.13.0] - 2019-10-02
 ### Added


### PR DESCRIPTION
Jason refuses to encode invalid JSON binaries, which results in an `{:error, %Jason.EncodeError{}}` result during encoding. We now match on encoding errors and attempt to coerce results into a valid binary.