### PR TITLE
Elixir 1.10 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 elixir:
   - 1.8
   - 1.9
-  - 1.10
+  - '1.10'
 otp_release:
   - 21.2
   - 22.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 elixir:
   - 1.8
   - 1.9
+  - 1.10
 otp_release:
   - 21.2
   - 22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Safely sanitize invalid binaries when encoding JSON for notices.
+- Fixes for Elixir 1.10 release (#259)
 
 ## [v0.13.0] - 2019-10-02
 ### Added

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -318,7 +318,7 @@ defmodule Honeybadger do
   @spec context(map() | keyword()) :: map()
   def context(map) when is_map(map), do: context(Keyword.new(map))
 
-  def context(keyword) do
+  def context(keyword) when is_list(keyword) do
     Logger.metadata(keyword)
 
     context()

--- a/lib/honeybadger/json.ex
+++ b/lib/honeybadger/json.ex
@@ -43,7 +43,8 @@ defmodule Honeybadger.JSON do
     |> to_encodeable
   end
 
-  defp to_encodeable(input) when is_pid(input) or is_port(input) or is_reference(input) do
+  defp to_encodeable(input)
+       when is_pid(input) or is_port(input) or is_reference(input) or is_function(input) do
     inspect(input)
   end
 

--- a/test/honeybadger/json_test.exs
+++ b/test/honeybadger/json_test.exs
@@ -40,7 +40,7 @@ defmodule Honeybadger.JSONTest do
 
     test "handles values requring inspection" do
       {:ok, ~s("&Honeybadger.JSON.encode/1")} = JSON.encode(&Honeybadger.JSON.encode/1)
-      {:ok, ~s("#PID<0.250.0>")} = JSON.encode(:c.pid(0,250,0))
+      {:ok, ~s("#PID<0.250.0>")} = JSON.encode(:c.pid(0, 250, 0))
 
       ref = make_ref()
       {:ok, encoded_ref} = JSON.encode(ref)

--- a/test/honeybadger/json_test.exs
+++ b/test/honeybadger/json_test.exs
@@ -38,6 +38,19 @@ defmodule Honeybadger.JSONTest do
       assert custom_encoded == jason_encoded
     end
 
+    test "handles values requring inspection" do
+      {:ok, ~s("&Honeybadger.JSON.encode/1")} = JSON.encode(&Honeybadger.JSON.encode/1)
+      {:ok, ~s("#PID<0.250.0>")} = JSON.encode(:c.pid(0,250,0))
+
+      ref = make_ref()
+      {:ok, encoded_ref} = JSON.encode(ref)
+      assert "\"#{inspect(ref)}\"" == encoded_ref
+
+      port = Port.open({:spawn, "false"}, [:binary])
+      {:ok, encoded_port} = JSON.encode(port)
+      assert "\"#{inspect(port)}\"" == encoded_port
+    end
+
     test "safely handling binaries with invalid bytes" do
       {:ok, ~s("honeybadger")} = JSON.encode(<<"honeybadger", 241>>)
       {:ok, ~s("honeybadger")} = JSON.encode(<<"honeybadger", 241, "yo">>)


### PR DESCRIPTION
Added 2 fixes to address test failures in 1.10.

* Looks like some extra data has been added to the Logger metadata in 1.10, one of which includes a reference to a function, which was not included in our safe_encoding clauses. I added that.

* There are some tests asserting that Honeybadger.context will fail with a `FunctionClauseError` when the wrong type is passed. The guards that were in place were removed at one point, but the underlying implementation of `Logger.metadata/1` still returned the same error. Welp, the implementation was updated, so now it returns a Protocol error instead. I added the `is_list` guard back.