### PR TITLE
Handle more edge cases in JSON encoding

### DIFF
--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -318,7 +318,7 @@ defmodule Honeybadger do
   @spec context(map() | keyword()) :: map()
   def context(map) when is_map(map), do: context(Keyword.new(map))
 
-  def context(keyword) do
+  def context(keyword) when is_list(keyword) do
     Logger.metadata(keyword)
 
     context()

--- a/lib/honeybadger/json.ex
+++ b/lib/honeybadger/json.ex
@@ -44,12 +44,13 @@ defmodule Honeybadger.JSON do
     |> to_encodeable
   end
 
-  defp to_encodeable(input) when is_pid(input) or is_port(input) or is_reference(input) do
-    inspect(input)
+  defp to_encodeable(input)
+       when is_number(input) or is_boolean(input) or is_binary(input) or is_atom(input) do
+    input
   end
 
   defp to_encodeable(input) do
-    input
+    inspect(input)
   end
 
   def safe_encode(input) do

--- a/test/honeybadger/json_test.exs
+++ b/test/honeybadger/json_test.exs
@@ -51,5 +51,61 @@ defmodule Honeybadger.JSONTest do
 
       assert json_encoded == jason_encoded
     end
+
+    test "encodes functions" do
+      {:ok, json_encoded} =
+        Notice.new(
+          %RuntimeError{message: "oops"},
+          %{
+            context: %{
+              log_format: &:gen_server.format_log/1
+            }
+          },
+          []
+        )
+        |> JSON.encode()
+
+      {:ok, jason_encoded} =
+        Notice.new(
+          %RuntimeError{message: "oops"},
+          %{
+            context: %{
+              log_format: "&:gen_server.format_log/1"
+            }
+          },
+          []
+        )
+        |> Jason.encode()
+
+      assert json_encoded == jason_encoded
+    end
+
+    test "encodes atoms as strings" do
+      {:ok, json_encoded} =
+        Notice.new(
+          %RuntimeError{message: "oops"},
+          %{
+            context: %{
+              status: :error
+            }
+          },
+          []
+        )
+        |> JSON.encode()
+
+      {:ok, jason_encoded} =
+        Notice.new(
+          %RuntimeError{message: "oops"},
+          %{
+            context: %{
+              status: "error"
+            }
+          },
+          []
+        )
+        |> Jason.encode()
+
+      assert json_encoded == jason_encoded
+    end
   end
 end


### PR DESCRIPTION
The JSON encoder tried to blacklist data types that needed to wrapped in `Kernel.inspect/1`, but that left at least one type (function) able to pass straight through to `Jason.encode/1`. That caused the entire Erlang VM to crash in same cases.

The commit changes the encoding logic to whitelist types that can be passed directly to `Jason.encode/1`, while wrapping everything else in `Kernel.inspect/1`.