### PR TITLE
Drop certain messages based on filter return value

### DIFF
--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -69,7 +69,7 @@ defmodule Honeybadger.Client do
   def send_notice(:drop_notice) do
     # Allow the caller to have certain messages dropped
     # by returning :drop_notice from a notice filter.
-    Logger.warn("HB not sending")
+    Logger.debug("[Honeybadger] Not sending message to Honeybadger because :drop_notice was returned by a NoticeFilter")
     :not_sent
   end
 

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -66,10 +66,10 @@ defmodule Honeybadger.Client do
     end
   end
 
-  def send_notice(_) do
+  def send_notice(:drop_notice) do
     # Allow the caller to have certain messages dropped
-    # by returning nil (or a non-map) from a notice filter.
-    Logger.warn("not sending")
+    # by returning :drop_notice from a notice filter.
+    Logger.warn("HB not sending")
     :not_sent
   end
 

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -66,6 +66,13 @@ defmodule Honeybadger.Client do
     end
   end
 
+  def send_notice(_) do
+    # Allow the caller to have certain messages dropped
+    # by returning nil (or a non-map) from a notice filter.
+    Logger.warn("not sending")
+    :not_sent
+  end
+
   @doc """
   Check whether reporting is enabled for the current environment.
 


### PR DESCRIPTION
Messages will be dropped if `:drop_notice` is returned from a notice filter, without crashing the Honeybadger lib.