### PR TITLE
Breadcrumbs on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
 - Breadcrumbs on by default
 
 ## [v0.13.1] - 2020-02-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Breadcrumbs on by default
 
 ## [v0.13.1] - 2020-02-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -127,20 +127,6 @@ transfer automatically. Since a typical system might have many processes, it
 is advised that you be conservative when storing breadcrumbs as each
 breadcrumb consumes memory.
 
-### Enabling Breadcrumbs
-
-As of version `0.13.0`, Breadcrumbs are _available_ yet _disabled_. You must
-explicitly enable them if you want breadcrumbs to be reported. We plan on
-enabling this by default in a future release.
-
-Toggle `breadcrumbs_enabled` in the config to start sending Breadcrumbs with
-notices:
-
-```elixir
-config :honeybadger,
-  breadcrumbs_enabled: true
-```
-
 ### Automatic Breadcrumbs
 
 We leverage the `telemetry` library to automatically create breadcrumbs from

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -16,7 +16,7 @@ defmodule Honeybadger do
         environment_name: :prod,
         app: :my_app_name,
         exclude_envs: [:dev, :test],
-        breadcrumbs_enabled: false,
+        breadcrumbs_enabled: true,
         ecto_repos: [MyAppName.Ecto.Repo],
         hostname: "myserver.domain.com",
         origin: "https://api.honeybadger.io",
@@ -135,12 +135,6 @@ defmodule Honeybadger do
   transfer automatically. Since a typical system might have many processes, it
   is advised that you be conservative when storing breadcrumbs as each
   breadcrumb consumes memory.
-
-  Ensure that you enable breadcrumbs in the config (as it is disabled by
-  default):
-
-      config :honeybadger,
-        breadcrumbs_enabled: true
 
   See `Honeybadger.add_breadcrumb` for info on how to add custom breadcrumbs.
 

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Honeybadger.Mixfile do
       env: [
         api_key: {:system, "HONEYBADGER_API_KEY"},
         app: nil,
-        breadcrumbs_enabled: false,
+        breadcrumbs_enabled: true,
         ecto_repos: [],
         environment_name: Mix.env(),
         exclude_envs: [:dev, :test],

--- a/test/honeybadger/breadcrumbs/collector_test.exs
+++ b/test/honeybadger/breadcrumbs/collector_test.exs
@@ -4,64 +4,58 @@ defmodule Honeybadger.Breadcrumbs.CollectorTest do
   alias Honeybadger.Breadcrumbs.{Collector, Breadcrumb}
 
   test "stores and outputs data" do
-    with_config([breadcrumbs_enabled: true], fn ->
-      bc1 = Breadcrumb.new("test1", [])
-      bc2 = Breadcrumb.new("test2", [])
-      Collector.add(bc1)
-      Collector.add(bc2)
-
-      assert Collector.output() == %{
-               enabled: true,
-               trail: [bc1, bc2]
-             }
-    end)
-  end
-
-  test "runs metadata through sanitizer" do
-    with_config([breadcrumbs_enabled: true], fn ->
-      bc1 =
-        Breadcrumb.new("test1",
-          metadata: %{
-            key1: %{key2: 12}
-          }
-        )
-
-      Collector.add(bc1)
-
-      assert List.first(Collector.output()[:trail]).metadata == %{
-               key1: "[DEPTH]"
-             }
-    end)
-  end
-
-  test "ignores when breadcrumbs are disabled" do
-    Collector.add("test1")
-    Collector.add("test2")
+    bc1 = Breadcrumb.new("test1", [])
+    bc2 = Breadcrumb.new("test2", [])
+    Collector.add(bc1)
+    Collector.add(bc2)
 
     assert Collector.output() == %{
-             enabled: false,
-             trail: []
+             enabled: true,
+             trail: [bc1, bc2]
            }
   end
 
-  test "clearing data" do
-    with_config([breadcrumbs_enabled: true], fn ->
-      Collector.add(Breadcrumb.new("test1", []))
-      Collector.clear()
+  test "runs metadata through sanitizer" do
+    bc1 =
+      Breadcrumb.new("test1",
+        metadata: %{
+          key1: %{key2: 12}
+        }
+      )
 
-      assert Collector.output()[:trail] == []
+    Collector.add(bc1)
+
+    assert List.first(Collector.output()[:trail]).metadata == %{
+             key1: "[DEPTH]"
+           }
+  end
+
+  test "ignores when breadcrumbs are disabled" do
+    with_config([breadcrumbs_enabled: false], fn ->
+      Collector.add("test1")
+      Collector.add("test2")
+
+      assert Collector.output() == %{
+               enabled: false,
+               trail: []
+             }
     end)
   end
 
+  test "clearing data" do
+    Collector.add(Breadcrumb.new("test1", []))
+    Collector.clear()
+
+    assert Collector.output()[:trail] == []
+  end
+
   test "allows put operation on supplied breadcrumb buffer" do
-    with_config([breadcrumbs_enabled: true], fn ->
-      bc = Breadcrumb.new("test1", [])
+    bc = Breadcrumb.new("test1", [])
 
-      breadcrumbs =
-        Collector.breadcrumbs()
-        |> Collector.put(bc)
+    breadcrumbs =
+      Collector.breadcrumbs()
+      |> Collector.put(bc)
 
-      assert Collector.output(breadcrumbs)[:trail] == [bc]
-    end)
+    assert Collector.output(breadcrumbs)[:trail] == [bc]
   end
 end


### PR DESCRIPTION
Change the default `breadcrumbs_enabled` config to `true`. I also removed any doc / readme mentions of needing to be enabled.

🦄 