### PR TITLE
Implement Jason.Encoder for RingBuffer

### DIFF
--- a/lib/honeybadger/breadcrumbs/ring_buffer.ex
+++ b/lib/honeybadger/breadcrumbs/ring_buffer.ex
@@ -5,6 +5,12 @@ defmodule Honeybadger.Breadcrumbs.RingBuffer do
 
   defstruct [:size, buffer: [], ct: 0]
 
+  defimpl Jason.Encoder do
+    def encode(buffer, opts) do
+      Jason.Encode.list(Honeybadger.Breadcrumbs.RingBuffer.to_list(buffer), opts)
+    end
+  end
+
   @spec new(pos_integer()) :: t()
   def new(size) do
     %__MODULE__{size: size}

--- a/test/honeybadger/breadcrumbs/ring_buffer_test.exs
+++ b/test/honeybadger/breadcrumbs/ring_buffer_test.exs
@@ -18,4 +18,13 @@ defmodule Honeybadger.Breadcrumbs.RingBufferTest do
 
     assert buffer == [:b, :c]
   end
+
+  test "implements Jason.Encoder" do
+    json =
+      RingBuffer.new(2)
+      |> RingBuffer.add(123)
+      |> Jason.encode!()
+
+    assert json == "[123]"
+  end
 end

--- a/test/honeybadger/breadcrumbs/ring_buffer_test.exs
+++ b/test/honeybadger/breadcrumbs/ring_buffer_test.exs
@@ -21,7 +21,8 @@ defmodule Honeybadger.Breadcrumbs.RingBufferTest do
 
   test "implements Jason.Encoder" do
     json =
-      RingBuffer.new(2)
+      2
+      |> RingBuffer.new()
       |> RingBuffer.add(123)
       |> Jason.encode!()
 


### PR DESCRIPTION
We use logger metadata as a storage area for intermediate Breadcrumbs. Before we serialize and send a notice, we extract the RingBuffer and transform it into its final Map form. We do all this assuming that nobody will look into our special logger metadata. Welp, we have had a report of another library trying to output the logger metadata (and failing to serialize).

This PR implements `Jason.Encoder` for our RingBuffer struct, extracting and outputting an array of breadcrumbs (or whatever was stored in the RingBuffer).