### PR TITLE
Update OTP version matrix with latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ elixir:
   - '1.10'
 otp_release:
   - 21.2
-  - 22.0
+  - 22.3
+  - 23.0
 env:
   - MIX_ENV=test
 script:
@@ -18,6 +19,11 @@ cache:
     - deps
     - _build
 jobs:
+  exclude:
+    - elixir: 1.8
+      otp_release: 23.0
+    - elixir: 1.9
+      otp_release: 23.0
   include:
     - stage: format
       env:


### PR DESCRIPTION
This fixes current build failures stemming from incompatibilities between the latest Ecto version and OTP 22.0. It also adds the recently released OTP 23.0 to the test matrix.

Closes #298 