### PR TITLE
Fingerprint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ you!
 
 #### Manual reporting
 
-You can manually report rescued exceptions with the  `Honeybadger.notify!` function.
+You can manually report rescued exceptions with the  `Honeybadger.notify` function.
 
 ```elixir
 try do
   File.read! "this_file_really_should_exist_dang_it.txt"
 rescue
   exception ->
-    Honeybadger.notify!(exception, metadata: %{}, stacktrace: __STACKTRACE__, fingerprint: "")
+    Honeybadger.notify(exception, metadata: %{}, stacktrace: __STACKTRACE__, fingerprint: "")
 end
 ```
 
@@ -222,11 +222,11 @@ Here are all of the options you can pass in the keyword list:
 
 ## Public Interface
 
-### `Honeybadger.notify!`: Send an exception to Honeybadger.
+### `Honeybadger.notify`: Send an exception to Honeybadger.
 
-Use the `Honeybadger.notify!/2` function to send exception information to the
+Use the `Honeybadger.notify/2` function to send exception information to the
 collector API.  The first parameter is the exception and the second parameter
-is the context/metadata/fingerprint. There is also a `Honeybadger.notify!/1` which doesn't require the second parameter.
+is the context/metadata/fingerprint. There is also a `Honeybadger.notify/1` which doesn't require the second parameter.
 
 #### Examples:
 
@@ -236,7 +236,7 @@ try do
 rescue
   exception ->
     context = %{user_id: 5, account_name: "Foo"}
-    Honeybadger.notify!(exception, metadata: context, stacktrace: __STACKTRACE__)
+    Honeybadger.notify(exception, metadata: context, stacktrace: __STACKTRACE__)
 end
 ```
 
@@ -267,14 +267,14 @@ end
 
 `Honeybadger.context/1` stores the context data in the process dictionary, so
 it will be sent with errors/notifications on the same process. The following
-`Honeybadger.notify!/1` call will not see the context data set in the previous line.
+`Honeybadger.notify/1` call will not see the context data set in the previous line.
 
 ```elixir
 Honeybadger.context(user_id: 5)
 Task.start(fn ->
   # this notify does not see the context set earlier
   # as this runs in a different elixir/erlang process.
-  Honeybadger.notify!(%RuntimeError{message: "critical error"})
+  Honeybadger.notify(%RuntimeError{message: "critical error"})
 end)
 ```
 

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ you!
 
 #### Manual reporting
 
-You can manually report rescued exceptions with the  `Honeybadger.notify` function.
+You can manually report rescued exceptions with the  `Honeybadger.notify!` function.
 
 ```elixir
 try do
   File.read! "this_file_really_should_exist_dang_it.txt"
 rescue
   exception ->
-    Honeybadger.notify(exception, %{}, __STACKTRACE__)
+    Honeybadger.notify!(exception, metadata: %{}, stacktrace: __STACKTRACE__, fingerprint: "")
 end
 ```
 
@@ -223,9 +223,9 @@ Here are all of the options you can pass in the keyword list:
 
 ### `Honeybadger.notify`: Send an exception to Honeybadger.
 
-Use the `Honeybadger.notify/2` function to send exception information to the
+Use the `Honeybadger.notify!/2` function to send exception information to the
 collector API.  The first parameter is the exception and the second parameter
-is the context/metadata. There is also a `Honeybadger.notify/1` which doesn't require the second parameter.
+is the context/metadata/fingerprint. There is also a `Honeybadger.notify!/1` which doesn't require the second parameter.
 
 #### Examples:
 
@@ -235,7 +235,7 @@ try do
 rescue
   exception ->
     context = %{user_id: 5, account_name: "Foo"}
-    Honeybadger.notify(exception, context, __STACKTRACE__)
+    Honeybadger.notify!(exception, metadata: context, stacktrace: __STACKTRACE__)
 end
 ```
 
@@ -266,14 +266,14 @@ end
 
 `Honeybadger.context/1` stores the context data in the process dictionary, so
 it will be sent with errors/notifications on the same process. The following
-`Honeybadger.notify/1` call will not see the context data set in the previous line.
+`Honeybadger.notify!/1` call will not see the context data set in the previous line.
 
 ```elixir
 Honeybadger.context(user_id: 5)
 Task.start(fn ->
   # this notify does not see the context set earlier
   # as this runs in a different elixir/erlang process.
-  Honeybadger.notify(%RuntimeError{message: "critical error"})
+  Honeybadger.notify!(%RuntimeError{message: "critical error"})
 end)
 ```
 

--- a/README.md
+++ b/README.md
@@ -214,14 +214,15 @@ Here are all of the options you can pass in the keyword list:
 | `filter_disable_url`     | If true, will remove the request url                                                          | `false`                                  |
 | `filter_disable_session` | If true, will remove the request session                                                      | `false`                                  |
 | `filter_disable_params`  | If true, will remove the request params                                                       | `false`                                  |
+| `fingerprint_adapter`    | Implementation of FingerprintAdapter behaviour                                                |                                          |
 | `notice_filter`          | Module implementing `Honeybadger.NoticeFilter`. If `nil`, no filtering is done.               | `Honeybadger.NoticeFilter.Default`       |
 | `use_logger`             | Enable the Honeybadger Logger for handling errors outside of web requests                     | `true`                                   |
 | `breadcrumbs_enabled`    | Enable breadcrumb event tracking                                                              | `false`                                  |
-| `ecto_repos`             | Modules with implemented Ecto.Repo behaviour for tracking SQL breadcrumb events               | `[]`                                    |
+| `ecto_repos`             | Modules with implemented Ecto.Repo behaviour for tracking SQL breadcrumb events               | `[]`                                     |
 
 ## Public Interface
 
-### `Honeybadger.notify`: Send an exception to Honeybadger.
+### `Honeybadger.notify!`: Send an exception to Honeybadger.
 
 Use the `Honeybadger.notify!/2` function to send exception information to the
 collector API.  The first parameter is the exception and the second parameter

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -41,7 +41,12 @@ defmodule Honeybadger do
         exception ->
           context = %{user_id: 1, account: "A Very Important Customer"}
 
-          Honeybadger.notify(exception, metadata: context, stacktrace: __STACKTRACE__, fingerprint: "user-1")
+          Honeybadger.notify(
+            exception,
+            metadata: context,
+            stacktrace: __STACKTRACE__,
+            fingerprint: "user-1"
+          )
       end
 
   Note that `notify` may be used outside of `try`, but it will use a different

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -256,13 +256,13 @@ defmodule Honeybadger do
         }
 
   @spec notify(Notice.noticeable()) :: :ok
-  @spec notify(Notice.noticeable(), notify_options) :: :ok
   def notify(exception) do
     notify(exception, [])
   end
 
+  @spec notify(Notice.noticeable(), notify_options) :: :ok
   def notify(exception, metadata) when is_map(metadata) do
-    Logger.warn(
+    IO.warn(
       "Passing a metadata map is deprecated, " <>
         "use Honeybadger.notify(exception, metadata: metadata) instead"
     )
@@ -294,8 +294,10 @@ defmodule Honeybadger do
     |> Client.send_notice()
   end
 
+  @doc deprecated: "Use Honeybadger.notify/2 instead"
+  @spec notify(Notice.noticeable(), map(), list()) :: :ok
   def notify(exception, metadata, stacktrace) when is_map(metadata) and is_list(stacktrace) do
-    Logger.warn("Reporting with notify/3 is deprecated, use notify/2 instead")
+    IO.warn("Reporting with notify/3 is deprecated, use notify/2 instead")
     notify(exception, metadata: metadata, stacktrace: stacktrace)
   end
 

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -251,7 +251,7 @@ defmodule Honeybadger do
 
   @type notify_options :: %{
           metadata: map(),
-          stacktrace: list(),
+          stacktrace: Exception.stacktrace_entry(),
           fingerprint: String.t()
         }
 

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -32,7 +32,7 @@ defmodule Honeybadger do
   ### Notifying
 
   If you use `Honeybadger.Plug` and `Honeybadger.Logger` included in this
-  library you won't need to use `Honeybadger.notify/3` for manual reporting
+  library you won't need to use `Honeybadger.notify!/2` for manual reporting
   very often. However, if you need to send custom notifications you can do so:
 
       try do
@@ -41,10 +41,10 @@ defmodule Honeybadger do
         exception ->
           context = %{user_id: 1, account: "A Very Important Customer"}
 
-          Honeybadger.notify(exception, context, __STACKTRACE__)
+          Honeybadger.notify!(exception, metadata: context, stacktrace: __STACKTRACE__, fingerprint: "user-1")
       end
 
-  Note that `notify` may be used outside of `try`, but it will use a different
+  Note that `notify!` may be used outside of `try`, but it will use a different
   mechanism for getting the current stacktrace. The resulting stacktrace may be
   noisier and less accurate.
 
@@ -219,31 +219,36 @@ defmodule Honeybadger do
         do_something_risky()
       rescue
         exception ->
-          Honeybadger.notify(exception, %{}, __STACKTRACE__)
+          Honeybadger.notify!(exception, metadata: %{}, stacktrace: __STACKTRACE__)
       end
 
   Send a notification directly from a string, which will be sent as a
   `RuntimeError`:
 
-      iex> Honeybadger.notify("custom error message")
+      iex> Honeybadger.notify!("custom error message")
       :ok
 
   Send a notification as a `class` and `message`:
 
-      iex> Honeybadger.notify(%{class: "SpecialError", message: "custom message"})
+      iex> Honeybadger.notify!(%{class: "SpecialError", message: "custom message"})
       :ok
 
   Send a notification as a `badarg` atom:
 
-      iex> Honeybadger.notify(:badarg)
+      iex> Honeybadger.notify!(:badarg)
       :ok
 
   If desired additional metadata can be provided as well:
 
-      iex> Honeybadger.notify(%RuntimeError{}, %{culprit_id: 123})
+      iex> Honeybadger.notify!(%RuntimeError{}, metadata: %{culprit_id: 123})
+      :ok
+
+  If desired fingerprint can be provided as well:
+
+      iex> Honeybadger.notify!(%RuntimeError{}, fingerprint: "culprit_id-123")
       :ok
   """
-  # @spec notify(Notice.noticeable(), map(), list()) :: :ok
+  @spec notify(Notice.noticeable(), map(), list()) :: :ok
   def notify(exception, metadata \\ %{}, stacktrace \\ []) when is_map(metadata) do
     Logger.warn(
       "Honeybadger.notify/1, Honeybadger.notify/2 and Honeybadger.notify/3 are deprecated, please use Honeybadger.notify!/2 instead"
@@ -252,6 +257,13 @@ defmodule Honeybadger do
     notify!(exception, metadata: metadata, stacktrace: stacktrace)
   end
 
+  @type notify_options :: %{
+          metadata: map(),
+          stacktrace: list(),
+          fingerprint: String.t()
+        }
+
+  @spec notify!(Notice.noticeable(), notify_options) :: :ok
   def notify!(exception, options \\ []) do
     metadata = options[:metadata] || %{}
     stacktrace = options[:stacktrace] || []

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -248,6 +248,15 @@ defmodule Honeybadger do
       iex> Honeybadger.notify(%RuntimeError{}, fingerprint: "culprit_id-123")
       :ok
   """
+
+  @type notify_options :: %{
+          metadata: map(),
+          stacktrace: list(),
+          fingerprint: String.t()
+        }
+
+  @spec notify(Notice.noticeable()) :: :ok
+  @spec notify(Notice.noticeable(), notify_options) :: :ok
   def notify(exception) do
     notify(exception, [])
   end
@@ -261,18 +270,6 @@ defmodule Honeybadger do
     notify(exception, metadata: metadata)
   end
 
-  def notify(exception, metadata, stacktrace) when is_map(metadata) and is_list(stacktrace) do
-    Logger.warn("Reporting with notify/3 is deprecated, use notify/2 instead")
-    notify(exception, metadata: metadata, stacktrace: stacktrace)
-  end
-
-  @type notify_options :: %{
-          metadata: map(),
-          stacktrace: list(),
-          fingerprint: String.t()
-        }
-
-  @spec notify(Notice.noticeable(), notify_options) :: :ok
   def notify(exception, options) do
     metadata = options[:metadata] || %{}
     stacktrace = options[:stacktrace] || []
@@ -295,6 +292,11 @@ defmodule Honeybadger do
     |> Notice.new(metadata_with_breadcrumbs, stacktrace, fingerprint)
     |> put_notice_fingerprint()
     |> Client.send_notice()
+  end
+
+  def notify(exception, metadata, stacktrace) when is_map(metadata) and is_list(stacktrace) do
+    Logger.warn("Reporting with notify/3 is deprecated, use notify/2 instead")
+    notify(exception, metadata: metadata, stacktrace: stacktrace)
   end
 
   defp put_notice_fingerprint(notice) do

--- a/lib/honeybadger/fingerprint_adapter.ex
+++ b/lib/honeybadger/fingerprint_adapter.ex
@@ -4,9 +4,8 @@ defmodule Honeybadger.FingerprintAdapter do
   """
 
   @doc """
-  For applications that specifies a fingerprint_adapter. This function receives
-  a Notice and must return a string that will be used as a fingerprint for the
-  request:
+  This function receives a `t:Notice.t/0` and must return a string that will be used as a
+  fingerprint for the request:
 
   def parse(notice) do
     notice.notifier.language <> "_" <> notice.notifier.name

--- a/lib/honeybadger/fingerprint_adapter.ex
+++ b/lib/honeybadger/fingerprint_adapter.ex
@@ -3,5 +3,14 @@ defmodule Honeybadger.FingerprintAdapter do
   The callbacks required to implement the FingerprintAdapter behaviour
   """
 
+  @doc """
+  For applications that specifies a fingerprint_adapter. This function receives
+  a Notice and must return a string that will be used as a fingerprint for the
+  request:
+
+  def parse(notice) do
+    notice.notifier.language <> "_" <> notice.notifier.name
+  end
+  """
   @callback parse(Notice.noticeable()) :: String.t()
 end

--- a/lib/honeybadger/fingerprint_adapter.ex
+++ b/lib/honeybadger/fingerprint_adapter.ex
@@ -1,0 +1,7 @@
+defmodule Honeybadger.FingerprintAdapter do
+  @moduledoc """
+  The callbacks required to implement the FingerprintAdapter behaviour
+  """
+
+  @callback parse(Notice.noticeable()) :: String.t()
+end

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -77,7 +77,7 @@ defmodule Honeybadger.Logger do
       |> Map.delete(Collector.metadata_key())
       |> Map.put(:breadcrumbs, breadcrumbs)
 
-    Honeybadger.notify(reason, metadata_with_breadcrumbs, stacktrace)
+    Honeybadger.notify!(reason, metadata: metadata_with_breadcrumbs, stacktrace: stacktrace)
   end
 
   @standard_metadata ~w(ancestors callers crash_reason file function line module pid)a

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -77,7 +77,7 @@ defmodule Honeybadger.Logger do
       |> Map.delete(Collector.metadata_key())
       |> Map.put(:breadcrumbs, breadcrumbs)
 
-    Honeybadger.notify!(reason, metadata: metadata_with_breadcrumbs, stacktrace: stacktrace)
+    Honeybadger.notify(reason, metadata: metadata_with_breadcrumbs, stacktrace: stacktrace)
   end
 
   @standard_metadata ~w(ancestors callers crash_reason file function line module pid)a

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -33,14 +33,14 @@ defmodule Honeybadger.Notice do
   defstruct [:breadcrumbs, :notifier, :server, :error, :request]
 
   @spec new(noticeable(), map(), list(), String.t()) :: t()
-  def new(error, metadata, stacktrace, fingerprint)
+  def new(error, metadata, stacktrace, fingerprint \\ "")
 
   def new(message, metadata, stacktrace, fingerprint)
       when is_binary(message) and is_map(metadata) and is_list(stacktrace) do
     new(%RuntimeError{message: message}, metadata, stacktrace, fingerprint)
   end
 
-  def new(exception, metadata, stacktrace, fingerprint \\ "")
+  def new(exception, metadata, stacktrace, fingerprint)
       when is_map(metadata) and is_list(stacktrace) do
     {exception, stacktrace} = Exception.blame(:error, exception, stacktrace)
 

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -32,15 +32,16 @@ defmodule Honeybadger.Notice do
   @enforce_keys [:breadcrumbs, :notifier, :server, :error, :request]
   defstruct [:breadcrumbs, :notifier, :server, :error, :request]
 
-  @spec new(noticeable(), map(), list()) :: t()
-  def new(error, metadata, stacktrace)
+  @spec new(noticeable(), map(), list(), String.t()) :: t()
+  def new(error, metadata, stacktrace, fingerprint)
 
-  def new(message, metadata, stacktrace)
+  def new(message, metadata, stacktrace, fingerprint)
       when is_binary(message) and is_map(metadata) and is_list(stacktrace) do
-    new(%RuntimeError{message: message}, metadata, stacktrace)
+    new(%RuntimeError{message: message}, metadata, stacktrace, fingerprint)
   end
 
-  def new(exception, metadata, stacktrace) when is_map(metadata) and is_list(stacktrace) do
+  def new(exception, metadata, stacktrace, fingerprint \\ "")
+      when is_map(metadata) and is_list(stacktrace) do
     {exception, stacktrace} = Exception.blame(:error, exception, stacktrace)
 
     %{__struct__: exception_mod} = exception
@@ -49,7 +50,8 @@ defmodule Honeybadger.Notice do
       class: Utils.module_to_string(exception_mod),
       message: exception_mod.message(exception),
       backtrace: Backtrace.from_stacktrace(stacktrace),
-      tags: Map.get(metadata, :tags, [])
+      tags: Map.get(metadata, :tags, []),
+      fingerprint: fingerprint
     }
 
     request =

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -63,7 +63,7 @@ if Code.ensure_loaded?(Plug) do
           else
             Collector.add(Breadcrumb.from_error(reason))
             metadata = @plug_data.metadata(conn, __MODULE__)
-            Honeybadger.notify!(reason, metadata: metadata, stacktrace: stack)
+            Honeybadger.notify(reason, metadata: metadata, stacktrace: stack)
           end
         end
 

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -63,7 +63,7 @@ if Code.ensure_loaded?(Plug) do
           else
             Collector.add(Breadcrumb.from_error(reason))
             metadata = @plug_data.metadata(conn, __MODULE__)
-            Honeybadger.notify(reason, metadata, stack)
+            Honeybadger.notify!(reason, metadata: metadata, stacktrace: stack)
           end
         end
 

--- a/lib/mix/tasks/test.ex
+++ b/lib/mix/tasks/test.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Honeybadger.Test do
     {:ok, _started} = Application.ensure_all_started(:honeybadger)
 
     # send the notification
-    Honeybadger.notify!(%HoneybadgerTestingException{})
+    Honeybadger.notify(%HoneybadgerTestingException{})
 
     # this will block the mix task from stopping before
     # the genserver sends the notification to honeybadger

--- a/lib/mix/tasks/test.ex
+++ b/lib/mix/tasks/test.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Honeybadger.Test do
     {:ok, _started} = Application.ensure_all_started(:honeybadger)
 
     # send the notification
-    Honeybadger.notify(%HoneybadgerTestingException{})
+    Honeybadger.notify!(%HoneybadgerTestingException{})
 
     # this will block the mix task from stopping before
     # the genserver sends the notification to honeybadger

--- a/test/fingerprint_adapter_test.exs
+++ b/test/fingerprint_adapter_test.exs
@@ -11,7 +11,7 @@ defmodule Honeybadger.FingerprintAdapterTest do
     test "sending a notice with fingerprint adapter" do
       restart_with_config(exclude_envs: [], fingerprint_adapter: Honeybadger.CustomFingerprint)
 
-      Honeybadger.notify!("Custom error")
+      Honeybadger.notify("Custom error")
 
       assert_receive {:api_request, %{"error" => error}}
       assert error["fingerprint"] == "elixir - honeybadger-elixir"
@@ -20,7 +20,7 @@ defmodule Honeybadger.FingerprintAdapterTest do
     test "notifying with fingerprint overrides the fingerprint adapter" do
       restart_with_config(exclude_envs: [], fingerprint_adapter: Honeybadger.CustomFingerprint)
 
-      Honeybadger.notify!("Custom error", fingerprint: "my-fingerprint")
+      Honeybadger.notify("Custom error", fingerprint: "my-fingerprint")
 
       assert_receive {:api_request, %{"error" => error}}
       assert error["fingerprint"] == "my-fingerprint"
@@ -29,7 +29,7 @@ defmodule Honeybadger.FingerprintAdapterTest do
     test "sending a notice without fingerprint adapter" do
       restart_with_config(exclude_envs: [], fingerprint_adapter: nil)
 
-      Honeybadger.notify!("Custom error")
+      Honeybadger.notify("Custom error")
 
       assert_receive {:api_request, %{"error" => error}}
       assert error["fingerprint"] == ""

--- a/test/fingerprint_adapter_test.exs
+++ b/test/fingerprint_adapter_test.exs
@@ -1,0 +1,46 @@
+defmodule Honeybadger.FingerprintAdapterTest do
+  use Honeybadger.Case
+
+  setup do
+    {:ok, _} = Honeybadger.API.start(self())
+
+    on_exit(&Honeybadger.API.stop/0)
+  end
+
+  describe "fingerprint adapter" do
+    test "sending a notice with fingerprint adapter" do
+      restart_with_config(exclude_envs: [], fingerprint_adapter: Honeybadger.CustomFingerprint)
+
+      Honeybadger.notify!("Custom error")
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["fingerprint"] == "elixir - honeybadger-elixir"
+    end
+
+    test "notifying with fingerprint overrides the fingerprint adapter" do
+      restart_with_config(exclude_envs: [], fingerprint_adapter: Honeybadger.CustomFingerprint)
+
+      Honeybadger.notify!("Custom error", fingerprint: "my-fingerprint")
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["fingerprint"] == "my-fingerprint"
+    end
+
+    test "sending a notice without fingerprint adapter" do
+      restart_with_config(exclude_envs: [])
+
+      Honeybadger.notify!("Custom error")
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["fingerprint"] == ""
+    end
+  end
+end
+
+defmodule Honeybadger.CustomFingerprint do
+  @behaviour Honeybadger.FingerprintAdapter
+
+  def parse(notice) do
+    "#{notice.notifier.language} - #{notice.notifier.name}"
+  end
+end

--- a/test/fingerprint_adapter_test.exs
+++ b/test/fingerprint_adapter_test.exs
@@ -27,7 +27,7 @@ defmodule Honeybadger.FingerprintAdapterTest do
     end
 
     test "sending a notice without fingerprint adapter" do
-      restart_with_config(exclude_envs: [])
+      restart_with_config(exclude_envs: [], fingerprint_adapter: nil)
 
       Honeybadger.notify!("Custom error")
 

--- a/test/fingerprint_adapter_test.exs
+++ b/test/fingerprint_adapter_test.exs
@@ -14,7 +14,7 @@ defmodule Honeybadger.FingerprintAdapterTest do
       Honeybadger.notify("Custom error")
 
       assert_receive {:api_request, %{"error" => error}}
-      assert error["fingerprint"] == "elixir - honeybadger-elixir"
+      assert error["fingerprint"] == "elixir-honeybadger-elixir"
     end
 
     test "notifying with fingerprint overrides the fingerprint adapter" do
@@ -41,6 +41,6 @@ defmodule Honeybadger.CustomFingerprint do
   @behaviour Honeybadger.FingerprintAdapter
 
   def parse(notice) do
-    "#{notice.notifier.language} - #{notice.notifier.name}"
+    notice.notifier.language <> "-" <> notice.notifier.name
   end
 end

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -21,7 +21,7 @@ defmodule HoneybadgerTest do
             exception ->
               :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
           end
-        end)
+        end, :stderr)
 
       assert logged =~ ~s|Reporting with notify/3 is deprecated, use notify/2 instead|
 
@@ -49,7 +49,7 @@ defmodule HoneybadgerTest do
             exception ->
               :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
           end
-        end)
+        end, :stderr)
 
       assert logged =~ ~s|Reporting with notify/3 is deprecated, use notify/2 instead|
 

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -9,16 +9,176 @@ defmodule HoneybadgerTest do
     on_exit(&Honeybadger.API.stop/0)
   end
 
-  test "sending a notice on an active environment" do
-    restart_with_config(exclude_envs: [])
+  describe "deprecated Honeybadger.notify works" do
+    test "sending a notice on an active environment" do
+      restart_with_config(exclude_envs: [])
 
-    logged =
-      capture_log(fn ->
-        :ok = Honeybadger.notify(%RuntimeError{})
-        assert_receive {:api_request, _}
-      end)
+      logged =
+        capture_log(fn ->
+          :ok = Honeybadger.notify(%RuntimeError{})
+          assert_receive {:api_request, _}
+        end)
 
-    assert logged =~ ~s|[Honeybadger] API success: "{}"|
+      assert logged =~ ~s|[Honeybadger] API success: "{}"|
+
+      assert logged =~
+               ~s|Honeybadger.notify/1, Honeybadger.notify/2 and Honeybadger.notify/3 are deprecated, please use Honeybadger.notify!/2 instead|
+    end
+
+    test "sending a notice on an inactive environment doesn't make an HTTP request" do
+      restart_with_config(exclude_envs: [:dev, :test])
+
+      logged =
+        capture_log(fn ->
+          :ok = Honeybadger.notify(%RuntimeError{})
+        end)
+
+      refute logged =~ "[Honeybadger] API"
+
+      assert logged =~
+               ~s|Honeybadger.notify/1, Honeybadger.notify/2 and Honeybadger.notify/3 are deprecated, please use Honeybadger.notify!/2 instead|
+
+      refute_receive {:api_request, _}
+    end
+
+    test "sending a notice in an active environment without an API key doesn't make an HTTP request" do
+      restart_with_config(exclude_envs: [], api_key: nil)
+
+      logged =
+        capture_log(fn ->
+          :ok = Honeybadger.notify(%RuntimeError{})
+          refute_receive {:api_request, _}
+        end)
+
+      refute logged =~ "[Honeybadger] API"
+
+      assert logged =~
+               ~s|Honeybadger.notify/1, Honeybadger.notify/2 and Honeybadger.notify/3 are deprecated, please use Honeybadger.notify!/2 instead|
+    end
+
+    test "sending a notice with exception stacktrace" do
+      restart_with_config(exclude_envs: [])
+
+      try do
+        raise RuntimeError
+      rescue
+        exception ->
+          :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
+      end
+
+      assert_receive {:api_request, %{"error" => %{"backtrace" => backtrace}}}
+
+      traced = for %{"file" => file, "method" => fun} <- backtrace, do: {file, fun}
+
+      refute {"lib/process.ex", "info/1"} in traced
+      refute {"lib/honeybadger.ex", "backtrace/1"} in traced
+      refute {"lib/honeybadger.ex", "notify/3"} in traced
+
+      assert {"test/honeybadger_test.exs",
+              "test deprecated Honeybadger.notify works sending a notice with exception stacktrace/1"} in traced
+    end
+
+    test "sending a notice includes extra information" do
+      restart_with_config(exclude_envs: [])
+      fun = fn :hi -> nil end
+
+      try do
+        fun.(:boom)
+      rescue
+        exception ->
+          :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
+      end
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["class"] == "FunctionClauseError"
+      assert String.contains?(error["message"], ":boom")
+    end
+  end
+
+  describe "Honeybadger.notify!" do
+    test "sending a notice on an active environment" do
+      restart_with_config(exclude_envs: [])
+
+      logged =
+        capture_log(fn ->
+          :ok = Honeybadger.notify!(%RuntimeError{})
+          assert_receive {:api_request, _}
+        end)
+
+      assert logged =~ ~s|[Honeybadger] API success: "{}"|
+    end
+
+    test "sending a notice on an inactive environment doesn't make an HTTP request" do
+      restart_with_config(exclude_envs: [:dev, :test])
+
+      logged =
+        capture_log(fn ->
+          :ok = Honeybadger.notify!(%RuntimeError{})
+        end)
+
+      refute logged =~ "[Honeybadger] API"
+
+      refute_receive {:api_request, _}
+    end
+
+    test "sending a notice in an active environment without an API key doesn't make an HTTP request" do
+      restart_with_config(exclude_envs: [], api_key: nil)
+
+      logged =
+        capture_log(fn ->
+          :ok = Honeybadger.notify!(%RuntimeError{})
+          refute_receive {:api_request, _}
+        end)
+
+      refute logged =~ "[Honeybadger] API"
+    end
+
+    test "sending a notice with exception stacktrace" do
+      restart_with_config(exclude_envs: [])
+
+      try do
+        raise RuntimeError
+      rescue
+        exception ->
+          :ok = Honeybadger.notify!(exception, metadata: %{}, stacktrace: __STACKTRACE__)
+      end
+
+      assert_receive {:api_request, %{"error" => %{"backtrace" => backtrace}}}
+
+      traced = for %{"file" => file, "method" => fun} <- backtrace, do: {file, fun}
+
+      refute {"lib/process.ex", "info/1"} in traced
+      refute {"lib/honeybadger.ex", "backtrace/1"} in traced
+      refute {"lib/honeybadger.ex", "notify/3"} in traced
+
+      assert {"test/honeybadger_test.exs",
+              "test Honeybadger.notify! sending a notice with exception stacktrace/1"} in traced
+    end
+
+    test "sending a notice includes extra information" do
+      restart_with_config(exclude_envs: [])
+      fun = fn :hi -> nil end
+
+      try do
+        fun.(:boom)
+      rescue
+        exception ->
+          :ok = Honeybadger.notify!(exception, metadata: %{}, stacktrace: __STACKTRACE__)
+      end
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["class"] == "FunctionClauseError"
+      assert String.contains?(error["message"], ":boom")
+    end
+
+    test "sending a notice includes fingerprint" do
+      restart_with_config(exclude_envs: [])
+
+      Honeybadger.notify!("Custom error", fingerprint: "fingerprint-xpto")
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["fingerprint"] == "fingerprint-xpto"
+    end
   end
 
   test "warn if incomplete env" do
@@ -47,68 +207,6 @@ defmodule HoneybadgerTest do
       end)
 
     refute logged =~ ~s|mandatory :honeybadger config key api_key not set|
-  end
-
-  test "sending a notice on an inactive environment doesn't make an HTTP request" do
-    restart_with_config(exclude_envs: [:dev, :test])
-
-    logged =
-      capture_log(fn ->
-        :ok = Honeybadger.notify(%RuntimeError{})
-      end)
-
-    refute logged =~ "[Honeybadger] API"
-
-    refute_receive {:api_request, _}
-  end
-
-  test "sending a notice in an active environment without an API key doesn't make an HTTP request" do
-    restart_with_config(exclude_envs: [], api_key: nil)
-
-    logged =
-      capture_log(fn ->
-        :ok = Honeybadger.notify(%RuntimeError{})
-        refute_receive {:api_request, _}
-      end)
-
-    refute logged =~ "[Honeybadger] API"
-  end
-
-  test "sending a notice with exception stacktrace" do
-    restart_with_config(exclude_envs: [])
-
-    try do
-      raise RuntimeError
-    rescue
-      exception ->
-        :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
-    end
-
-    assert_receive {:api_request, %{"error" => %{"backtrace" => backtrace}}}
-
-    traced = for %{"file" => file, "method" => fun} <- backtrace, do: {file, fun}
-
-    refute {"lib/process.ex", "info/1"} in traced
-    refute {"lib/honeybadger.ex", "backtrace/1"} in traced
-    refute {"lib/honeybadger.ex", "notify/3"} in traced
-
-    assert {"test/honeybadger_test.exs", "test sending a notice with exception stacktrace/1"} in traced
-  end
-
-  test "sending a notice includes extra information" do
-    restart_with_config(exclude_envs: [])
-    fun = fn :hi -> nil end
-
-    try do
-      fun.(:boom)
-    rescue
-      exception ->
-        :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
-    end
-
-    assert_receive {:api_request, %{"error" => error}}
-    assert error["class"] == "FunctionClauseError"
-    assert String.contains?(error["message"], ":boom")
   end
 
   test "fetching all application values" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,14 +36,14 @@ defmodule Honeybadger.Case do
     :ok = Application.ensure_started(:honeybadger)
   end
 
-  def capture_log(fun) do
+  def capture_log(fun, device \\ :user) do
     Logger.add_backend(:console, flush: true)
 
     on_exit(fn ->
       Logger.remove_backend(:console)
     end)
 
-    ExUnit.CaptureIO.capture_io(:user, fn ->
+    ExUnit.CaptureIO.capture_io(device, fn ->
       fun.()
       :timer.sleep(100)
       Logger.flush()


### PR DESCRIPTION
Implementation for fingerprint option, as discussed in https://github.com/honeybadger-io/honeybadger-elixir/issues/233

- new `notify!/2` option that accepts `metadata, stacktrace and fingerprint`
```
# we can't add `notify!/2` and keep the old because it conflicts the defaults
(CompileError) lib/honeybadger.ex:267: def notify/2 conflicts with defaults from notify/3

# the new has keyword as default in second param
def notify(exception, options \\ [])

# the old has map as default in second param
def notify(exception, metadata \\ %{}, stacktrace \\ [])
```

- fingerprint adapter behaviour that receives a `Noticiable` and must return a string, the precedence is as follow:
  - fingerprint option in `notify!/2`
  - fingerprint adapter