### PR TITLE
Send notifications on error-level logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Send notifications on error-level logs
 
 ## [v0.15.0] - 2020-09-24
 ### Added

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -40,7 +40,7 @@ defmodule Honeybadger.Logger do
         notify(reason, full_context, [])
 
       _ ->
-        :ok
+        notify(%RuntimeError{message: message}, full_context, [])
     end
 
     {:ok, state}

--- a/test/honeybadger/logger_test.exs
+++ b/test/honeybadger/logger_test.exs
@@ -145,4 +145,11 @@ defmodule Honeybadger.LoggerTest do
 
     refute_receive {:api_request, _}
   end
+
+  test "handles error-level log" do
+    Logger.error("Error-level log")
+
+    assert_receive {:api_request, %{"breadcrumbs" => breadcrumbs}}
+    assert List.first(breadcrumbs["trail"])["metadata"]["message"] == "Error-level log"
+  end
 end


### PR DESCRIPTION
👋 
Relates to https://github.com/honeybadger-io/honeybadger-elixir/issues/276
I set the exception as `RuntimeError`, otherwise, the message will be with the prefix `Erlang Error:`. 

Should I add a configuration to disable and enable notifications?