### PR TITLE
Misc doc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ Elixir Plug, Logger and client for the :zap: [Honeybadger error notifier](https:
 
 [Watch our screencast](https://josh-rubyist.wistia.com/medias/pggpan0f9j) by Josh Adams of [ElixirSips](http://elixirsips.com/)!
 
-### 1. Install the package
+## Version requirements
 
-Prerequisites: minimum of Elixir 1.0 and Erlang 18.0
+- Erlang >= 18.0
+- Elixir >= 1.3
+- Plug >= 1.0
+- Phoenix >= 1.0 (This is an optional dependency and the version requirement applies only if you are using Phoenix)
+
+
+### 1. Install the package
 
 Add the Honeybadger package to `deps/0` in your
 application's `mix.exs` file and run `mix do deps.get, deps.compile`
@@ -318,12 +324,6 @@ config :honeybadger,
   exclude_envs: [:test]
 ```
 3. Run the `mix honeybadger.test` mix task task to simulate an error
-
-## Version requirements
-- Erlang >= 18.0
-- Elixir >= 1.3
-- Plug >= 1.0
-- Phoenix >= 1.0 (This is an optional dependency and the version requirement applies only if you are using Phoenix)
 
 ## Changelog
 

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -5,10 +5,10 @@ defmodule Honeybadger do
 
   ### Configuring
 
-  By default the HONEYBADGER_API_KEY environment variable is used to find
+  By default the `HONEYBADGER_API_KEY` environment variable is used to find
   your API key for Honeybadger. You can also manually set your API key by
-  configuring the :honeybadger application. You can see the default
-  configuration in the default_config/0 private function at the bottom of
+  configuring the `:honeybadger` application. You can see the default
+  configuration in the `default_config/0` private function at the bottom of
   this file.
 
       config :honeybadger,
@@ -95,8 +95,8 @@ defmodule Honeybadger do
   ### Using the Error Logger
 
   By default the logger is enabled. The logger will automatically receive any
-  error reports for SASL compliant processes such as GenServers, GenEvents,
-  Agents, Tasks and any process spawned using `proc_lib`. You can disable the
+  error reports for SASL compliant processes such as `GenServers`, `GenEvents`,
+  `Agents`, `Tasks` and any process spawned using `proc_lib`. You can disable the
   logger by setting `use_logger` to false in your Honeybadger config.
 
   ### Using a Notification Filter
@@ -213,7 +213,7 @@ defmodule Honeybadger do
 
   ## Stacktrace
 
-  Accessing the stacktrace outside of a rescue/catch is deprecated. Notifiations should happen
+  Accessing the stacktrace outside of a rescue/catch is deprecated. Notifications should happen
   inside of a rescue/catch block so that the stacktrace can be provided with `__STACKTRACE__`.
   Stacktraces _must_ be provided and won't be automatically extracted from the current process.
 

--- a/lib/honeybadger/fingerprint_adapter.ex
+++ b/lib/honeybadger/fingerprint_adapter.ex
@@ -9,9 +9,10 @@ defmodule Honeybadger.FingerprintAdapter do
   This function receives a `t:Honeybadger.Notice.t/0` and must return a string that will be used
   as a fingerprint for the request:
 
-  def parse(notice) do
-    notice.notifier.language <> "_" <> notice.notifier.name
-  end
+      def parse(notice) do
+        notice.notifier.language <> "_" <> notice.notifier.name
+      end
+
   """
   @callback parse(Notice.t()) :: String.t()
 end

--- a/lib/honeybadger/plug.ex
+++ b/lib/honeybadger/plug.ex
@@ -21,7 +21,7 @@ if Code.ensure_loaded?(Plug) do
 
     ## Customizing
 
-    Data reporting may be customized by passing an alterate `:plug_data`
+    Data reporting may be customized by passing an alternate `:plug_data`
     module. This is useful when working with alternate frameworks, such as
     Absinthe for GraphQL APIs.
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,13 @@
 defmodule Honeybadger.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/honeybadger-io/honeybadger-elixir"
+  @version "0.15.0"
+
   def project do
     [
       app: :honeybadger,
-      version: "0.15.0",
+      version: @version,
       elixir: "~> 1.7",
       consolidate_protocols: Mix.env() != :test,
       build_embedded: Mix.env() == :prod,
@@ -16,9 +19,10 @@ defmodule Honeybadger.Mixfile do
       package: package(),
       name: "Honeybadger",
       homepage_url: "https://honeybadger.io",
-      source_url: "https://github.com/honeybadger-io/honeybadger-elixir",
-      description:
-        "Elixir client, Plug and error_logger for integrating with the Honeybadger.io exception tracker",
+      description: """
+      Elixir client, Plug and error_logger for integrating with the
+      Honeybadger.io exception tracker"
+      """,
 
       # Dialyzer
       dialyzer: [
@@ -27,12 +31,18 @@ defmodule Honeybadger.Mixfile do
       ],
 
       # Docs
-      docs: [extras: ["README.md", "CHANGELOG.md"], main: "readme"]
+      docs: [
+        main: "readme",
+        source_ref: "v#{@version}",
+        source_url: @source_url,
+        extras: ["README.md", "CHANGELOG.md"]
+      ]
     ]
   end
 
-  # we use a non standard location for mix tasks as we don't want them to leak
-  # into the host apps mix tasks. This way our release task is shown only in our mix tasks
+  # We use a non standard location for mix tasks as we don't want them to leak
+  # into the host apps mix tasks. This way our release task is shown only in
+  # our mix tasks
   defp elixirc_paths(:dev), do: ["lib", "mix"]
   defp elixirc_paths(_), do: ["lib"]
 
@@ -72,7 +82,7 @@ defmodule Honeybadger.Mixfile do
       {:telemetry, "~> 0.4"},
 
       # Dev dependencies
-      {:ex_doc, "~> 0.7", only: :dev, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
 
       # Test dependencies
@@ -84,7 +94,10 @@ defmodule Honeybadger.Mixfile do
     [
       licenses: ["MIT"],
       maintainers: ["Joshua Wood"],
-      links: %{"GitHub" => "https://github.com/honeybadger-io/honeybadger-elixir"}
+      links: %{
+        "Changelog" => "#{@source_url}/blob/master/CHANGELOG.md",
+        "GitHub" => @source_url
+      }
     ]
   end
 end


### PR DESCRIPTION
List of changes:
- Use common source url
- Use latest ex_doc version
- Set source reference by tagged version
- Show the version requirement at top of doc
- Mix format module config
- Fix missing code indentation
- Fix typos
- Show changelog link in hex module info page