### PR TITLE
Ignored domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Here are all of the options you can pass in the keyword list:
 | `fingerprint_adapter`    | Implementation of FingerprintAdapter behaviour                                                |                                          |
 | `notice_filter`          | Module implementing `Honeybadger.NoticeFilter`. If `nil`, no filtering is done.               | `Honeybadger.NoticeFilter.Default`       |
 | `use_logger`             | Enable the Honeybadger Logger for handling errors outside of web requests                     | `true`                                   |
+| `ignored_domains`        | Add domains to ignore Error events in `Honeybadger.Logger`.                                   | `[:cowboy]`                              |
 | `breadcrumbs_enabled`    | Enable breadcrumb event tracking                                                              | `false`                                  |
 | `ecto_repos`             | Modules with implemented Ecto.Repo behaviour for tracking SQL breadcrumb events               | `[]`                                     |
 

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -11,7 +11,7 @@ defmodule Honeybadger.Logger do
   end
 
   def init({__MODULE__, opts}) when is_list(opts) do
-    {:ok, %{ level: Keyword.get(opts, :level) }}
+    {:ok, %{ level: opts[:level] }}
   end
 
   @impl true

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -11,7 +11,7 @@ defmodule Honeybadger.Logger do
   end
 
   def init({__MODULE__, opts}) when is_list(opts) do
-    {:ok, %{ level: opts[:level] }}
+    {:ok, %{level: opts[:level]}}
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Honeybadger.Mixfile do
         proxy: nil,
         proxy_auth: {nil, nil},
         use_logger: true,
+        ignored_domains: [:cowboy],
         notice_filter: Honeybadger.NoticeFilter.Default,
         filter: Honeybadger.Filter.Default,
         filter_keys: [:password, :credit_card],

--- a/test/honeybadger/logger_test.exs
+++ b/test/honeybadger/logger_test.exs
@@ -152,4 +152,14 @@ defmodule Honeybadger.LoggerTest do
     assert_receive {:api_request, %{"breadcrumbs" => breadcrumbs}}
     assert List.first(breadcrumbs["trail"])["metadata"]["message"] == "Error-level log"
   end
+
+  test "ignores specific logger domains" do
+    with_config([ignored_domains: [:neat]], fn ->
+      Task.start(fn ->
+        Logger.error("what", domain: [:neat])
+      end)
+
+      refute_receive {:api_request, _}
+    end)
+  end
 end


### PR DESCRIPTION
Should resolve #242 

This change allows for ignoring specific logger error events based on the log event domain metadata. Using the supplied defaults, this should deal with reported duplicate errors between Honeybadger.Plug and Honeybadger.Logger.

The logger will now ignore any events that are of the :cowboy domain by default. Since Phoenix integrates with cowboy to execute plugs, the cowboy error is often thrown at the same path as our Plug.ErrorHandler.

It's been a while since I have written any Elixir, so there might be better ways to do this. I'm also unsure if the method of pulling from the global config is best practice either.

I still need to add docs. I will do that next week.