### PR TITLE
Update the CI workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -5,37 +5,55 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    
+
 jobs:
   build:
     name: Build and test
 
+    env:
+      MIX_ENV: test
     strategy:
+      fail-fast: false
       matrix:
-        elixir: ['1.8', '1.9', '1.10']
-        otp: ['21.2', '22.3', '23.0']
-        exclude:
-            - elixir: '1.8'
-              otp: '23.0'
-            - elixir: '1.9'
-              otp: '23.0'
+        include:
+          - pair:
+              elixir: '1.8'
+              otp: '21.3'
+          - pair:
+              elixir: '1.11'
+              otp: '23.2'
+            lint: lint
 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Elixir
-        uses: actions/setup-elixir@v1
+
+      - uses: erlef/setup-elixir@v1
         with:
-          elixir-version: ${{ matrix.elixir }}
-          otp-version: ${{ matrix.otp }}
+          otp-version: ${{matrix.pair.otp}}
+          elixir-version: ${{matrix.pair.elixir}}
+
       - name: Restore dependencies cache
         uses: actions/cache@v2
         with:
           path: deps
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
-      - name: Install dependencies
-        run: mix deps.get
+          key: ${{ runner.os }}-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.pair.otp }}-${{ matrix.pair.elixir }}-mix-
+
+      - name: Run mix deps.get
+        run: mix deps.get --only test
+
+      - name: Run mix format
+        run: mix format --check-formatted
+        if: ${{ matrix.lint }}
+
+      - name: Run mix deps.compile
+        run: mix deps.compile
+
+      - name: Run mix compile
+        run: mix compile --warnings-as-errors
+        if: ${{ matrix.lint }}
+
       - name: Run tests
         run: mix test

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -84,7 +84,7 @@ defmodule Honeybadger.Logger do
     Enum.any?(ignored, fn ignore -> Enum.member?(domain, ignore) end)
   end
 
-  def domain_ignored?(_domain ,_ignored), do: false
+  def domain_ignored?(_domain, _ignored), do: false
 
   @standard_metadata ~w(ancestors callers crash_reason file function line module pid)a
 

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,9 @@ defmodule Honeybadger.Mixfile do
         flags: [:error_handling, :race_conditions, :underspecs]
       ],
 
+      # Xref
+      xref: [exclude: [Plug.Conn]],
+
       # Docs
       docs: [
         main: "readme",

--- a/mix/tasks/hex_release.ex
+++ b/mix/tasks/hex_release.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Release do
+defmodule Mix.Tasks.HexRelease do
   use Mix.Task
 
   @shortdoc "Publish package to hex.pm, create a git tag and push it to GitHub"

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -14,14 +14,17 @@ defmodule HoneybadgerTest do
       restart_with_config(exclude_envs: [])
 
       logged =
-        capture_log(fn ->
-          try do
-            raise RuntimeError
-          rescue
-            exception ->
-              :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
-          end
-        end, :stderr)
+        capture_log(
+          fn ->
+            try do
+              raise RuntimeError
+            rescue
+              exception ->
+                :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
+            end
+          end,
+          :stderr
+        )
 
       assert logged =~ ~s|Reporting with notify/3 is deprecated, use notify/2 instead|
 
@@ -42,14 +45,17 @@ defmodule HoneybadgerTest do
       fun = fn :hi -> nil end
 
       logged =
-        capture_log(fn ->
-          try do
-            fun.(:boom)
-          rescue
-            exception ->
-              :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
-          end
-        end, :stderr)
+        capture_log(
+          fn ->
+            try do
+              fun.(:boom)
+            rescue
+              exception ->
+                :ok = Honeybadger.notify(exception, %{}, __STACKTRACE__)
+            end
+          end,
+          :stderr
+        )
 
       assert logged =~ ~s|Reporting with notify/3 is deprecated, use notify/2 instead|
 


### PR DESCRIPTION
Update the CI workflow to repair builds, improve timing and enhance checks:

* Use the erlef/setup-elixir task for otp/elixir versions
* Only test the oldest and newest supported versions
* Run linting on the latest version combiation

Currently, broken CI is preventing even simple dependabot PRs from merging.
