### PR TITLE
Fix custom class and message notices

### DIFF
--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -47,15 +47,27 @@ defmodule Honeybadger.Notice do
     new(%RuntimeError{message: message}, metadata, stacktrace, fingerprint)
   end
 
+  def new(%{class: exception_name, message: message}, metadata, stacktrace, fingerprint) do
+    do_new(exception_name, message, metadata, stacktrace, fingerprint)
+  end
+
   def new(exception, metadata, stacktrace, fingerprint)
       when is_map(metadata) and is_list(stacktrace) do
     {exception, stacktrace} = Exception.blame(:error, exception, stacktrace)
 
     %{__struct__: exception_mod} = exception
 
+    class = Utils.module_to_string(exception_mod)
+    message = exception_mod.message(exception)
+
+    do_new(class, message, metadata, stacktrace, fingerprint)
+  end
+
+  # bundles exception (or pseudo exception) information in to notice
+  defp do_new(class, message, metadata, stacktrace, fingerprint) do
     error = %{
-      class: Utils.module_to_string(exception_mod),
-      message: exception_mod.message(exception),
+      class: class,
+      message: message,
       backtrace: Backtrace.from_stacktrace(stacktrace),
       tags: Map.get(metadata, :tags, []),
       fingerprint: fingerprint

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -49,7 +49,7 @@ defmodule Honeybadger.Notice do
 
   def new(%{class: exception_name, message: message}, metadata, stacktrace, fingerprint)
       when is_map(metadata) and is_list(stacktrace) do
-    do_new(exception_name, message, metadata, stacktrace, fingerprint)
+    new(exception_name, message, metadata, stacktrace, fingerprint)
   end
 
   def new(exception, metadata, stacktrace, fingerprint)
@@ -61,11 +61,11 @@ defmodule Honeybadger.Notice do
     class = Utils.module_to_string(exception_mod)
     message = exception_mod.message(exception)
 
-    do_new(class, message, metadata, stacktrace, fingerprint)
+    new(class, message, metadata, stacktrace, fingerprint)
   end
 
   # bundles exception (or pseudo exception) information in to notice
-  defp do_new(class, message, metadata, stacktrace, fingerprint) do
+  defp new(class, message, metadata, stacktrace, fingerprint) do
     error = %{
       class: class,
       message: message,

--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -47,7 +47,8 @@ defmodule Honeybadger.Notice do
     new(%RuntimeError{message: message}, metadata, stacktrace, fingerprint)
   end
 
-  def new(%{class: exception_name, message: message}, metadata, stacktrace, fingerprint) do
+  def new(%{class: exception_name, message: message}, metadata, stacktrace, fingerprint)
+      when is_map(metadata) and is_list(stacktrace) do
     do_new(exception_name, message, metadata, stacktrace, fingerprint)
   end
 

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -149,6 +149,16 @@ defmodule HoneybadgerTest do
       assert_receive {:api_request, %{"error" => error}}
       assert error["fingerprint"] == "fingerprint-xpto"
     end
+
+    test "sending a notice with custom class and message" do
+      restart_with_config(exclude_envs: [])
+
+      Honeybadger.notify(%{class: "CustomError", message: "a message"})
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert "CustomError" = error["class"]
+      assert "a message" = error["message"]
+    end
   end
 
   test "warn if incomplete env" do


### PR DESCRIPTION
It seemed that 

```
iex(__@__)4> Honeybadger.notify(%{class: "CustomClass", message: "a matching message"})
:ok
```

Were not being reported in the way they should:

![image](https://user-images.githubusercontent.com/866010/115002238-d8fc9d00-9ee7-11eb-8b3f-2362bf3e310a.png)

Adds new function head to match the custom format. I can't imagine any "real" exception would ever match that pattern, they should all be structs, so ... probably safe?

See also: #336 

NB "class" is kind of a weird term (over maybe "type" or even just "name") in Elixir but I assume it's to keep the API uniform across languages.

