### PR TITLE
Encode notice message iodata before json serialize

### DIFF
--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -68,7 +68,7 @@ defmodule Honeybadger.Notice do
   defp new(class, message, metadata, stacktrace, fingerprint) do
     error = %{
       class: class,
-      message: message,
+      message: IO.iodata_to_binary(message),
       backtrace: Backtrace.from_stacktrace(stacktrace),
       tags: Map.get(metadata, :tags, []),
       fingerprint: fingerprint

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -159,6 +159,17 @@ defmodule HoneybadgerTest do
       assert "CustomError" = error["class"]
       assert "a message" = error["message"]
     end
+
+    test "sending a notice when the message is an improper list of iodata" do
+      restart_with_config(exclude_envs: [])
+
+      message = ["RealError", 32, 40, "#PID<0.1.0>" | " ** Error"]
+
+      Honeybadger.notify(%RuntimeError{message: message})
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["message"] == "RealError (#PID<0.1.0> ** Error"
+    end
   end
 
   test "warn if incomplete env" do


### PR DESCRIPTION
Notice messages are sometimes provided as iodata, which may be an improper list where the last cons is to a binary rather than a list. That format isn't encodeable by Jason and causes a function clause error in `Jason.Encode.list_loop/3`. This caused a secondary error to fire for every error with an improper list.

This fixes the situation by converting iodata to binary before encoding and sending the notice.

Closes #356
