### PR TITLE
Use Logger.warn for rate limit errors

### DIFF
--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -88,7 +88,7 @@ defmodule Honeybadger.Client do
     env_name = get_env(opts, :environment_name)
     excluded = get_env(opts, :exclude_envs)
 
-    not (maybe_to_atom(env_name) in excluded)
+    maybe_to_atom(env_name) not in excluded
   end
 
   # Callbacks
@@ -156,6 +156,10 @@ defmodule Honeybadger.Client do
       {:ok, code, _headers, ref} when code in 200..399 ->
         body = body_from_ref(ref)
         Logger.debug(fn -> "[Honeybadger] API success: #{inspect(body)}" end)
+
+      {:ok, code, _headers, ref} when code == 429 ->
+        body = body_from_ref(ref)
+        Logger.warn(fn -> "[Honeybadger] API failure: #{inspect(body)}" end)
 
       {:ok, code, _headers, ref} when code in 400..599 ->
         body = body_from_ref(ref)


### PR DESCRIPTION
Prevents an infinite loop occurring where a rate limit error triggers
a another notification

This is a naive fix for #352 but not sure if it is the preferred solution.