### PR TITLE
Fix iodata nil message issue

### DIFF
--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -66,9 +66,11 @@ defmodule Honeybadger.Notice do
 
   # bundles exception (or pseudo exception) information in to notice
   defp new(class, message, metadata, stacktrace, fingerprint) do
+    message = if message, do: IO.iodata_to_binary(message), else: nil
+
     error = %{
       class: class,
-      message: IO.iodata_to_binary(message),
+      message: message,
       backtrace: Backtrace.from_stacktrace(stacktrace),
       tags: Map.get(metadata, :tags, []),
       fingerprint: fingerprint

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -170,6 +170,15 @@ defmodule HoneybadgerTest do
       assert_receive {:api_request, %{"error" => error}}
       assert error["message"] == "RealError (#PID<0.1.0> ** Error"
     end
+
+    test "sending a notice when the message is nil" do
+      restart_with_config(exclude_envs: [])
+
+      Honeybadger.notify(%RuntimeError{message: nil})
+
+      assert_receive {:api_request, %{"error" => error}}
+      assert error["message"] == nil
+    end
   end
 
   test "warn if incomplete env" do


### PR DESCRIPTION
Fixes issue in Notice where IO.iodata_to_binary/1 would throw an ArgumentError exception if passed a nil message.
