### PR TITLE
Handle extra_info with error_info

### DIFF
--- a/lib/honeybadger/backtrace.ex
+++ b/lib/honeybadger/backtrace.ex
@@ -24,13 +24,11 @@ defmodule Honeybadger.Backtrace do
     Enum.map(stacktrace, &format_line/1)
   end
 
-  defp format_line({mod, fun, args, []}) do
-    format_line({mod, fun, args, [file: nil, line: nil]})
-  end
-
-  defp format_line({mod, fun, args, [file: file, line: line]}) do
+  defp format_line({mod, fun, args, extra_info}) do
     app = Honeybadger.get_env(:app)
     filter_args = Honeybadger.get_env(:filter_args)
+    file = Keyword.get(extra_info, :file)
+    line = Keyword.get(extra_info, :line)
 
     %{
       file: format_file(file),

--- a/test/honeybadger/backtrace_test.exs
+++ b/test/honeybadger/backtrace_test.exs
@@ -9,7 +9,7 @@ defmodule Honeybadger.BacktraceTest do
       {Honeybadger, :notify, [%RuntimeError{message: "error"}, %{a: 1}, [:a, :b]],
        [file: 'lib/honeybadger.ex', line: 38]},
       {Honeybadger.Backtrace, :from_stacktrace, 1,
-       [file: 'lib/honeybadger/backtrace.ex', line: 4]}
+       [file: 'lib/honeybadger/backtrace.ex', line: 4, error_info: %{module: :erl_erts_errors}]}
     ]
 
     with_config([filter_args: false], fn ->


### PR DESCRIPTION
The stacktrace `extra_info` field can contain an `error_info` tuple, along with the `file` and `line` tuples.

https://erlang.org/doc/reference_manual/errors.html#the-call-stack-back-trace--stacktrace-

My application was generating a stacktrace with an extra_info field that contained error_info. This was caused a FunctionClauseError exception when calling Honeybadger.Backtrace.format_line. This PR solves this issue.