### PR TITLE
Prevent internal error from causing infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Handle `extra_info` with `error_info` in `Honeybadger.Backtrace.format_line` (#369, @abstractcoder)
-
 - Prevent internal error from causing infinite loop (#370)
 
 ## [v0.16.2] - 2021-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Handle `extra_info` with `error_info` in `Honeybadger.Backtrace.format_line` (#369, @abstractcoder)
 
+- Prevent internal error from causing infinite loop (#370)
+
 ## [v0.16.2] - 2021-04-27
 ### Fixed
 - Encode notice message iodata before json serialize (#361)

--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -163,10 +163,10 @@ defmodule Honeybadger.Client do
 
       {:ok, code, _headers, ref} when code in 400..599 ->
         body = body_from_ref(ref)
-        Logger.error(fn -> "[Honeybadger] API failure: #{inspect(body)}" end)
+        Logger.warn(fn -> "[Honeybadger] API failure: #{inspect(body)}" end)
 
       {:error, reason} ->
-        Logger.error(fn -> "[Honeybadger] connection error: #{inspect(reason)}" end)
+        Logger.warn(fn -> "[Honeybadger] connection error: #{inspect(reason)}" end)
     end
   end
 

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -26,7 +26,7 @@ defmodule Honeybadger.Logger do
 
   def handle_event({:error, _gl, {Logger, message, _ts, metadata}}, state) do
     unless domain_ignored?(metadata[:domain], Honeybadger.get_env(:ignored_domains)) ||
-             internal_error?(metadata) do
+             internal_error?(metadata[:application]) do
       details = extract_details(message)
       context = extract_context(metadata)
       full_context = Map.merge(details, context)
@@ -87,11 +87,10 @@ defmodule Honeybadger.Logger do
 
   def domain_ignored?(_domain, _ignored), do: false
 
-  def internal_error?(metadata) do
-    case Keyword.get(metadata, :application) do
-      nil -> false
-      application -> application == :honeybadger
-    end
+  def internal_error?(nil), do: false
+
+  def internal_error?(application) do
+    application == :honeybadger
   end
 
   @standard_metadata ~w(ancestors callers crash_reason file function line module pid)a

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -24,7 +24,7 @@ defmodule Honeybadger.Logger do
     {:ok, state}
   end
 
-  def handle_event({:error, _gl, {Logger, message, _ts, metadata}} = messo, state) do
+  def handle_event({:error, _gl, {Logger, message, _ts, metadata}}, state) do
     unless domain_ignored?(metadata[:domain], Honeybadger.get_env(:ignored_domains)) ||
              internal_error?(metadata) do
       details = extract_details(message)

--- a/test/honeybadger/logger_test.exs
+++ b/test/honeybadger/logger_test.exs
@@ -162,4 +162,12 @@ defmodule Honeybadger.LoggerTest do
       refute_receive {:api_request, _}
     end)
   end
+
+  test "ignores internal error" do
+    Logger.error("ignores internal error")
+    assert_receive {:api_request, _}
+
+    Logger.error("ignores internal error", application: :honeybadger)
+    refute_receive {:api_request, _}
+  end
 end


### PR DESCRIPTION
This PR solves the issue  #352 . 
The problem is that when our API responds with an error code, and then we call `Logger. error`, the `use_logger `feature causes an additional error report to be sent, which causes the API to respond with another error, and it becomes an infinite cycle.
This has been done by first checking the Logger metadata received 
```
[
  erl_level: :error,
  application: :honeybadger,
  domain: [:elixir],
  file: "lib/honeybadger/client.ex",
  function: "post_notice/4",
  gl: #PID<0.465.0>,
  line: 181,
  mfa: {Honeybadger.Client, :post_notice, 4},
  module: Honeybadger.Client,
  pid: #PID<0.469.0>,
  time: 1625259235761950
]
```
If the application from metadata is `:honeybadger`,  the error notification is not sent to honeybadger API

Fixes #352 
Closes #372 