### PR TITLE
show arguments in stacktrace

### DIFF
--- a/lib/honeybadger/notice.ex
+++ b/lib/honeybadger/notice.ex
@@ -54,7 +54,7 @@ defmodule Honeybadger.Notice do
 
   def new(exception, metadata, stacktrace, fingerprint)
       when is_map(metadata) and is_list(stacktrace) do
-    {exception, stacktrace} = Exception.blame(:error, exception, stacktrace)
+    {exception, _stacktrace} = Exception.blame(:error, exception, stacktrace)
 
     %{__struct__: exception_mod} = exception
 


### PR DESCRIPTION
This PR is related to #123 
 I have found out that, the stack trace is been parsed at this [notice.ex line 57](https://github.com/honeybadger-io/honeybadger-elixir/blob/master/lib/honeybadger/notice.ex#L57) Hence for the limited cases like FunctionClauseError, the arguments are not available for the final output. 
Here is the stack trace before  been parsed:
```
{HelloWeb.PageController, :match, [%{}],
   [file: 'lib/hello_web/controllers/page_controller.ex', line: 28]}
```
After been parsed at [notice.ex line 57](https://github.com/honeybadger-io/honeybadger-elixir/blob/master/lib/honeybadger/notice.ex#L57):
```
{HelloWeb.PageController, :match, 1,
   [file: 'lib/hello_web/controllers/page_controller.ex', line: 28]}
```