### PR TITLE
Make notification for Logger.error configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Here are all of the options you can pass in the keyword list:
 | `filter_disable_params`  | If true, will remove the request params                                                       | `false`                                  |
 | `fingerprint_adapter`    | Implementation of FingerprintAdapter behaviour                                                |                                          |
 | `notice_filter`          | Module implementing `Honeybadger.NoticeFilter`. If `nil`, no filtering is done.               | `Honeybadger.NoticeFilter.Default`       |
+| `notify_for_error_logs`  | Enable sending notifications for Logger.error calls                                           | `false`
 | `use_logger`             | Enable the Honeybadger Logger for handling errors outside of web requests                     | `true`                                   |
 | `ignored_domains`        | Add domains to ignore Error events in `Honeybadger.Logger`.                                   | `[:cowboy]`                              |
 | `breadcrumbs_enabled`    | Enable breadcrumb event tracking                                                              | `false`                                  |

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Here are all of the options you can pass in the keyword list:
 | `filter_disable_params`  | If true, will remove the request params                                                       | `false`                                  |
 | `fingerprint_adapter`    | Implementation of FingerprintAdapter behaviour                                                |                                          |
 | `notice_filter`          | Module implementing `Honeybadger.NoticeFilter`. If `nil`, no filtering is done.               | `Honeybadger.NoticeFilter.Default`       |
-| `notify_for_error_logs`  | Enable sending notifications for Logger.error calls                                           | `false`
+| `sasl_logging_only`      | If true, will notifiy for SASL errors but not Logger calls                                    | `true`                                   |
 | `use_logger`             | Enable the Honeybadger Logger for handling errors outside of web requests                     | `true`                                   |
 | `ignored_domains`        | Add domains to ignore Error events in `Honeybadger.Logger`.                                   | `[:cowboy]`                              |
 | `breadcrumbs_enabled`    | Enable breadcrumb event tracking                                                              | `false`                                  |

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -20,7 +20,7 @@ defmodule Honeybadger do
         ecto_repos: [MyAppName.Ecto.Repo],
         hostname: "myserver.domain.com",
         origin: "https://api.honeybadger.io",
-        notify_for_error_logs: true,
+        sasl_logging_only: false,
         proxy: "http://proxy.net:PORT",
         proxy_auth: {"Username", "Password"},
         project_root: "/home/skynet",

--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -20,6 +20,7 @@ defmodule Honeybadger do
         ecto_repos: [MyAppName.Ecto.Repo],
         hostname: "myserver.domain.com",
         origin: "https://api.honeybadger.io",
+        notify_for_error_logs: true,
         proxy: "http://proxy.net:PORT",
         proxy_auth: {"Username", "Password"},
         project_root: "/home/skynet",

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -39,7 +39,7 @@ defmodule Honeybadger.Logger do
           notify(reason, full_context, [])
 
         _ ->
-          if get_config(:notify_for_error_logs) do
+          unless get_config(:sasl_logging_only) do
             notify(%RuntimeError{message: message}, full_context, [])
           end
       end

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -39,7 +39,9 @@ defmodule Honeybadger.Logger do
           notify(reason, full_context, [])
 
         _ ->
-          notify(%RuntimeError{message: message}, full_context, [])
+          if get_config(:notify_for_error_logs) do
+            notify(%RuntimeError{message: message}, full_context, [])
+          end
       end
     end
 
@@ -116,5 +118,9 @@ defmodule Honeybadger.Logger do
 
   defp extract_details(_message) do
     %{}
+  end
+
+  defp get_config(key) do
+    Application.get_env(:honeybadger, key)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -59,6 +59,7 @@ defmodule Honeybadger.Mixfile do
         ecto_repos: [],
         environment_name: Mix.env(),
         exclude_envs: [:dev, :test],
+        notify_for_error_logs: false,
         origin: "https://api.honeybadger.io",
         proxy: nil,
         proxy_auth: {nil, nil},

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Honeybadger.Mixfile do
         ecto_repos: [],
         environment_name: Mix.env(),
         exclude_envs: [:dev, :test],
-        notify_for_error_logs: false,
+        sasl_logging_only: true,
         origin: "https://api.honeybadger.io",
         proxy: nil,
         proxy_auth: {nil, nil},

--- a/test/honeybadger/logger_test.exs
+++ b/test/honeybadger/logger_test.exs
@@ -156,11 +156,10 @@ defmodule Honeybadger.LoggerTest do
   end
 
   test "ignores error-level log when disabled" do
-    with_config([notify_for_error_logs: true], fn ->
+    with_config([notify_for_error_logs: false], fn ->
       Logger.error("Error-level log")
 
-      assert_receive {:api_request, %{"breadcrumbs" => breadcrumbs}}
-      assert List.first(breadcrumbs["trail"])["metadata"]["message"] == "Error-level log"
+      refute_receive {:api_request, _}
     end)
   end
 

--- a/test/honeybadger/logger_test.exs
+++ b/test/honeybadger/logger_test.exs
@@ -147,7 +147,7 @@ defmodule Honeybadger.LoggerTest do
   end
 
   test "handles error-level log when enabled" do
-    with_config([notify_for_error_logs: true], fn ->
+    with_config([sasl_logging_only: false], fn ->
       Logger.error("Error-level log")
 
       assert_receive {:api_request, %{"breadcrumbs" => breadcrumbs}}
@@ -156,7 +156,7 @@ defmodule Honeybadger.LoggerTest do
   end
 
   test "ignores error-level log when disabled" do
-    with_config([notify_for_error_logs: false], fn ->
+    with_config([sasl_logging_only: true], fn ->
       Logger.error("Error-level log")
 
       refute_receive {:api_request, _}
@@ -174,7 +174,7 @@ defmodule Honeybadger.LoggerTest do
   end
 
   test "ignores internal error" do
-    with_config([notify_for_error_logs: true], fn ->
+    with_config([sasl_logging_only: false], fn ->
       Logger.error("ignores internal error")
       assert_receive {:api_request, _}
 


### PR DESCRIPTION
Follow up to upstream issue #315; adds a configuration key for controlling whether Logger.error sends a Honeybadger notification. Default is false.