### PR TITLE
Support latest telemetry dependency.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -84,7 +84,7 @@ defmodule Honeybadger.Mixfile do
       {:plug, ">= 1.0.0 and < 2.0.0", optional: true},
       {:ecto, ">= 2.0.0", optional: true},
       {:phoenix, ">= 1.0.0 and < 2.0.0", optional: true},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
 
       # Dev dependencies
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Be more flexible with telemetry version to avoid blocking `deps.update`.
Common pattern, see elixir-ecto/ecto_sql@7209cce and beam-telemetry/telemetry_metrics@ddc41e5

Ref https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md#100