### PR TITLE
Avoid local function captures in Telemetry.attrach_many/4

### DIFF
--- a/lib/honeybadger/breadcrumbs/telemetry.ex
+++ b/lib/honeybadger/breadcrumbs/telemetry.ex
@@ -1,6 +1,8 @@
 defmodule Honeybadger.Breadcrumbs.Telemetry do
   @moduledoc false
 
+  alias __MODULE__
+
   @spec telemetry_events() :: [[atom()]]
   def telemetry_events do
     []
@@ -13,7 +15,7 @@ defmodule Honeybadger.Breadcrumbs.Telemetry do
     :telemetry.attach_many(
       "hb-telemetry",
       telemetry_events(),
-      &handle_telemetry/4,
+      &Telemetry.handle_telemetry/4,
       nil
     )
 


### PR DESCRIPTION
Local function captures should be avoided as they may cause performance penalty when calling such handler.
For more details see note in [Telemetry.attach_many/4](https://hexdocs.pm/telemetry/telemetry.html#attach_many/4) documentation.