### PR TITLE
bump suggested version on README and bump lang versions on CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,8 +20,8 @@ jobs:
               elixir: '1.10'
               otp: '21.3'
           - pair:
-              elixir: '1.12'
-              otp: '24.0'
+              elixir: '1.14'
+              otp: '25.1'
             lint: lint
 
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ application's `mix.exs` file and run `mix do deps.get, deps.compile`
 
 ```elixir
 defp deps do
-  [{:honeybadger, "~> 0.16"}]
+  [{:honeybadger, "~> 0.19"}]
 end
 ```
 


### PR DESCRIPTION
Hey 👋🏾 

We are migrating our project to run use Honeybadger and I noticed the upper "supported" versions are `24.0` for otp and `1.12` for elixir. However our system runs on newer `25.1` and  `1.14.2` versions, because of that I'm stretching version limits.

It seems like it works as expected from initial tests, but I would like to ensure you are supposed to work with the versions we are using, and that we will have no unexpected regressions before we start to drop money on you. Pairing the CI with newer versions help with that. Ideally I would reccomend to run a [matrix strategy](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy) to test against all versions in between the limits.

I also took the opportunity to point readme to a newer version once the suggested `honeybadger` dep is legging behind by almost 2 years.


