### PR TITLE
Allow for hackney options

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -63,6 +63,7 @@ defmodule Honeybadger.Mixfile do
         origin: "https://api.honeybadger.io",
         proxy: nil,
         proxy_auth: {nil, nil},
+        hackney_opts: [],
         use_logger: true,
         ignored_domains: [:cowboy],
         notice_filter: Honeybadger.NoticeFilter.Default,


### PR DESCRIPTION
This PR makes it possible to set `:hackney_opts` in the configuration which is passed onto hackney. I didn't see any tests of configuration, but this works in local for me. This resolves the first part of #467.

To force IPv6 with hackney I can now set the config with:

```elixir
config :honeybadger,
  # ...
  hackney_opts: [connect_options: [:inet6]]
```

But dual stack could still be an issue since it'll always default to IPv4 in hackney.

As discussed in #467 it would be better if it was possible to pass in a HTTP client adapter. That would remove things that arguably should be outside the scope of this library, like the HTTP proxy tunnel or the connection pool. The default startup could still include hackney with some sane defaults (e.g. starting connection pool).