### PR TITLE
Stop using logger metadata for breadcrumbs

### DIFF
--- a/lib/honeybadger.ex
+++ b/lib/honeybadger.ex
@@ -369,7 +369,7 @@ defmodule Honeybadger do
   """
   @spec context() :: map()
   def context do
-    Logger.metadata() |> Map.new() |> Map.delete(Collector.metadata_key())
+    Map.new(Logger.metadata())
   end
 
   @doc """

--- a/lib/honeybadger/breadcrumbs/collector.ex
+++ b/lib/honeybadger/breadcrumbs/collector.ex
@@ -1,35 +1,34 @@
 defmodule Honeybadger.Breadcrumbs.Collector do
   @moduledoc false
 
-  @doc """
-  The Collector provides an interface for accessing and affecting the current
-  set of breadcrumbs. Most operations are delegated to the supplied Buffer
-  implementation. This is mainly for internal use.
-  """
+  # The Collector provides an interface for accessing and affecting the current set of
+  # breadcrumbs. Most operations are delegated to the supplied Buffer implementation. This is
+  # mainly for internal use.
 
   alias Honeybadger.Breadcrumbs.{RingBuffer, Breadcrumb}
   alias Honeybadger.Utils
 
-  @buffer_impl RingBuffer
   @buffer_size 40
-  @metadata_key :hb_breadcrumbs
+  @collector_key :hb_breadcrumbs
 
   @type t :: %{enabled: boolean(), trail: [Breadcrumb.t()]}
+
+  def key, do: @collector_key
 
   @spec output() :: t()
   def output(), do: output(breadcrumbs())
 
-  @spec output(@buffer_impl.t()) :: t()
+  @spec output(RingBuffer.t()) :: t()
   def output(breadcrumbs) do
     %{
       enabled: Honeybadger.get_env(:breadcrumbs_enabled),
-      trail: @buffer_impl.to_list(breadcrumbs)
+      trail: RingBuffer.to_list(breadcrumbs)
     }
   end
 
-  @spec put(@buffer_impl.t(), Breadcrumb.t()) :: @buffer_impl.t()
+  @spec put(RingBuffer.t(), Breadcrumb.t()) :: RingBuffer.t()
   def put(breadcrumbs, breadcrumb) do
-    @buffer_impl.add(
+    RingBuffer.add(
       breadcrumbs,
       Map.update(breadcrumb, :metadata, %{}, &Utils.sanitize(&1, max_depth: 1))
     )
@@ -38,7 +37,7 @@ defmodule Honeybadger.Breadcrumbs.Collector do
   @spec add(Breadcrumb.t()) :: :ok
   def add(breadcrumb) do
     if Honeybadger.get_env(:breadcrumbs_enabled) do
-      Logger.metadata([{@metadata_key, put(breadcrumbs(), breadcrumb)}])
+      Process.put(@collector_key, put(breadcrumbs(), breadcrumb))
     end
 
     :ok
@@ -46,14 +45,11 @@ defmodule Honeybadger.Breadcrumbs.Collector do
 
   @spec clear() :: :ok
   def clear() do
-    Logger.metadata([{@metadata_key, @buffer_impl.new(@buffer_size)}])
+    Process.put(@collector_key, RingBuffer.new(@buffer_size))
   end
 
-  def metadata_key(), do: @metadata_key
-
-  @spec breadcrumbs() :: @buffer_impl.t()
+  @spec breadcrumbs() :: RingBuffer.t()
   def breadcrumbs() do
-    Logger.metadata()
-    |> Keyword.get(@metadata_key, @buffer_impl.new(@buffer_size))
+    Process.get(@collector_key, RingBuffer.new(@buffer_size))
   end
 end

--- a/lib/honeybadger/breadcrumbs/telemetry.ex
+++ b/lib/honeybadger/breadcrumbs/telemetry.ex
@@ -24,10 +24,7 @@ defmodule Honeybadger.Breadcrumbs.Telemetry do
 
   @spec append_phoenix_events([[atom()]]) :: [[atom()]]
   defp append_phoenix_events(events) do
-    Enum.concat(
-      events,
-      [[:phoenix, :router_dispatch, :start]]
-    )
+    Enum.concat(events, [[:phoenix, :router_dispatch, :start]])
   end
 
   @spec append_ecto_events([[atom()]]) :: [[atom()]]
@@ -49,7 +46,8 @@ defmodule Honeybadger.Breadcrumbs.Telemetry do
   end
 
   def handle_telemetry(_path, %{decode_time: _} = time, %{query: _} = meta, _) do
-    Map.merge(time, meta)
+    time
+    |> Map.merge(meta)
     |> handle_sql()
   end
 

--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -70,15 +70,8 @@ defmodule Honeybadger.Logger do
   ## Helpers
 
   defp notify(reason, metadata, stacktrace) do
-    breadcrumbs =
-      metadata
-      |> Map.get(Collector.metadata_key(), Collector.breadcrumbs())
-      |> Collector.put(Breadcrumb.from_error(reason))
-
-    metadata_with_breadcrumbs =
-      metadata
-      |> Map.delete(Collector.metadata_key())
-      |> Map.put(:breadcrumbs, breadcrumbs)
+    breadcrumbs = Collector.put(Collector.breadcrumbs(), Breadcrumb.from_error(reason))
+    metadata_with_breadcrumbs = Map.put(metadata, :breadcrumbs, breadcrumbs)
 
     Honeybadger.notify(reason, metadata: metadata_with_breadcrumbs, stacktrace: stacktrace)
   end

--- a/test/honeybadger/breadcrumbs/collector_test.exs
+++ b/test/honeybadger/breadcrumbs/collector_test.exs
@@ -9,10 +9,7 @@ defmodule Honeybadger.Breadcrumbs.CollectorTest do
     Collector.add(bc1)
     Collector.add(bc2)
 
-    assert Collector.output() == %{
-             enabled: true,
-             trail: [bc1, bc2]
-           }
+    assert Collector.output() == %{enabled: true, trail: [bc1, bc2]}
   end
 
   test "runs metadata through sanitizer" do
@@ -25,9 +22,7 @@ defmodule Honeybadger.Breadcrumbs.CollectorTest do
 
     Collector.add(bc1)
 
-    assert List.first(Collector.output()[:trail]).metadata == %{
-             key1: "[DEPTH]"
-           }
+    assert List.first(Collector.output()[:trail]).metadata == %{key1: "[DEPTH]"}
   end
 
   test "ignores when breadcrumbs are disabled" do
@@ -35,10 +30,7 @@ defmodule Honeybadger.Breadcrumbs.CollectorTest do
       Collector.add("test1")
       Collector.add("test2")
 
-      assert Collector.output() == %{
-               enabled: false,
-               trail: []
-             }
+      assert Collector.output() == %{enabled: false, trail: []}
     end)
   end
 


### PR DESCRIPTION
Breadcrumbs used the logger metadata for convenient access to the process dictionary. That's not necessary, and it makes standard metadata logging unusable when shipping logs to a third party service.

This moves breadcrumb storage to a separate key in the process dictionary.

Closes #475