### PR TITLE
chore: replace `Plug.Adapter.Cowboy` with `Plug.Cowboy`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -94,7 +94,7 @@ defmodule Honeybadger.Mixfile do
       {:expublish, "~> 2.5", only: [:dev], runtime: false},
 
       # Test dependencies
-      {:plug_cowboy, ">= 1.0.0 and < 3.0.0", only: :test}
+      {:plug_cowboy, ">= 2.0.0 and < 3.0.0", only: :test}
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -65,7 +65,7 @@ defmodule Honeybadger.API do
   import Plug.Conn
 
   alias Plug.Conn
-  alias Plug.Adapters.Cowboy
+  alias Plug.Cowboy
 
   def start(pid) do
     Cowboy.http(__MODULE__, [test: pid], port: 4444)


### PR DESCRIPTION
Closes #524

Replaces the use of `Plug.Adapter.Cowboy` with `Plug.Cowby`, which is where it was moved with `plug_cowby > 2.0.0`. I also bumped version to a minimum of `2.0.0`.