### PR TITLE
Bump versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Setup Elixir
         uses: erlef/setup-elixir@v1
         with:
-          otp-version: '24.0'
-          elixir-version: '1.12'
+          otp-version: '24.3'
+          elixir-version: '1.15'
 
       - name: Restore dependencies cache
         uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ erl_crash.dump
 /doc
 RELEASE.md
 .idea
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Elixir Plug, Logger and client for the :zap: [Honeybadger error notifier](https:
 
 ### Version Requirements
 
-- Erlang >= 21.0
-- Elixir >= 1.11
-- Plug >= 1.0
+- Erlang >= 24.0
+- Elixir >= 1.15
+- Plug >= 1.10
 - Phoenix >= 1.0 (This is an optional dependency and the version requirement applies only if you are using Phoenix)
 
 ### 1. Install the package


### PR DESCRIPTION
The publish task failed because of an unsupported function in 1.12, so I figured it was time for a bump.

I bumped the README versions as well. Along with Elixir and Erlang, I set the min version for Plug as `1.10` seems to be the [last version getting security patches](https://hexdocs.pm/plug/readme.html#supported-versions). I did not do the same for Phoenix as I did not find the same info (the supported versions table in the docs are very handy). 

Also, should we bump the min version for plug in our `mix.exs`, even though its optional?