### PR TITLE
Sanitizer updates

### DIFF
--- a/test/honeybadger/utils_test.exs
+++ b/test/honeybadger/utils_test.exs
@@ -30,6 +30,20 @@ defmodule Honeybadger.UtilsTest do
     assert Utils.sanitize(item, max_depth: 2) == [["[DEPTH]"], 1, 2, 3]
   end
 
+  test "converts dates to ISO8601" do
+    item = %{
+      date: ~D[2023-10-01],
+      datetime: ~U[2023-10-01 12:00:00Z],
+      naive_datetime: ~N[2023-10-01 12:00:00]
+    }
+
+    assert Utils.sanitize(item) == %{
+             date: "2023-10-01",
+             datetime: "2023-10-01T12:00:00Z",
+             naive_datetime: "2023-10-01T12:00:00"
+           }
+  end
+
   test "sanitize truncates strings" do
     item = "123456789"
 
@@ -45,6 +59,19 @@ defmodule Honeybadger.UtilsTest do
     assert Utils.sanitize(item, filter_keys: [:filter_me]) == %{
              filter_me: "[FILTERED]",
              okay: "not a secret at all"
+           }
+  end
+
+  test "sanitize removes nested keys" do
+    item = %{
+      key1: "val1",
+      key2: %{
+        __remove__: "val2"
+      }
+    }
+
+    assert Utils.sanitize(item, filter_keys: [:__remove__], remove_filtered: true) == %{
+             key1: "val1"
            }
   end
 end


### PR DESCRIPTION
* Convert date like structs to a ISO8601 representation
* If sanitizing removes all keys from a nested map, remove the root key as well.