### PR TITLE
Revised event logging

### DIFF
--- a/lib/honeybadger/client.ex
+++ b/lib/honeybadger/client.ex
@@ -284,14 +284,14 @@ defmodule Honeybadger.Client do
   defp process_and_log_events_response(events, %{"errors" => true, "events" => res_events}) do
     Logger.debug("[Honeybadger] Events API (#{length(events)} events sent) with errors:")
 
-    res_events
-    |> Enum.with_index()
-    |> Enum.each(fn {%{"status" => status}, index} when status != 200 ->
-      event_str = events |> Enum.at(index) |> inspect()
-
-      Logger.warning(fn ->
-        "[Honeybadger] Event error: #{status}\nEvent: #{event_str}"
-      end)
+    events
+    |> Enum.zip(res_events)
+    |> Enum.each(fn {event, %{"status" => status}} ->
+      if status != 200 && status != 201 do
+        Logger.warning(fn ->
+          "[Honeybadger] Event error: #{status}\nEvent: #{inspect(event)}"
+        end)
+      end
     end)
   end
 

--- a/lib/honeybadger/events_worker.ex
+++ b/lib/honeybadger/events_worker.ex
@@ -165,7 +165,6 @@ defmodule Honeybadger.EventsWorker do
         %{batch: batch, attempts: attempts} = b, {acc, false} ->
           case state.send_events_fn.(batch) do
             :ok ->
-              Logger.debug("[Honeybadger] Sent batch of #{length(batch)} events.")
               {acc, false}
 
             {:error, reason} ->

--- a/test/honeybadger/http_adapter/hackney_test.exs
+++ b/test/honeybadger/http_adapter/hackney_test.exs
@@ -84,6 +84,17 @@ defmodule Honeybadger.HTTPAdapter.HackneyTest do
              Hackney.decode_response_body(
                %HTTPResponse{
                  body: @json_encoded_body,
+                 headers: [{"Content-Type", "application/json"}]
+               },
+               []
+             )
+
+    assert response.body == @body
+
+    assert {:ok, response} =
+             Hackney.decode_response_body(
+               %HTTPResponse{
+                 body: @json_encoded_body,
                  headers: [{"content-type", "text/javascript"}]
                },
                []


### PR DESCRIPTION
resolves #607

This prints out less in the debug logs for successful event API responses. It also prints the event data to the warn log for any non 200 event responses.

![CleanShot 2025-04-22 at 16 13 29@2x](https://github.com/user-attachments/assets/701fa78c-6adf-44e6-9e73-badddf250e30)
