### PR TITLE
Allow event sample rates

### DIFF
--- a/lib/honeybadger/events_sampler.ex
+++ b/lib/honeybadger/events_sampler.ex
@@ -50,7 +50,9 @@ defmodule Honeybadger.EventsSampler do
   """
   @spec sample?(Keyword.t()) :: boolean()
   def sample?(opts \\ []) do
-    server = Keyword.get(opts, :server, __MODULE__)
+    {server, opts} = Keyword.pop(opts, :server, __MODULE__)
+    # Remove nil values from options
+    opts = Keyword.filter(opts, fn {_k, v} -> not is_nil(v) end)
 
     if sampling_at_full_rate?(opts) do
       true

--- a/lib/honeybadger/events_sampler.ex
+++ b/lib/honeybadger/events_sampler.ex
@@ -31,11 +31,11 @@ defmodule Honeybadger.EventsSampler do
   end
 
   @doc """
-  Determines if an event should be sampled based on its hash value.
+  Determines if an event should be sampled
 
   ## Options
     * `:sample_rate` - Override the default sample rate from the server state
-    * `:hash_value` - The hash value to use for sampling. If not provided, a random value is used.
+    * `:hash_value` - The hash value to use for sampling. If not provided, random sampling is used.
     * `:server` - Specify the GenServer to use (default: `__MODULE__`)
 
   ## Examples

--- a/lib/honeybadger/events_sampler.ex
+++ b/lib/honeybadger/events_sampler.ex
@@ -10,12 +10,8 @@ defmodule Honeybadger.EventsSampler do
   @fully_sampled_rate 100
 
   def start_link(opts \\ []) do
-    if Honeybadger.get_env(:insights_sample_rate) == @fully_sampled_rate do
-      :ignore
-    else
-      {name, opts} = Keyword.pop(opts, :name, __MODULE__)
-      GenServer.start_link(__MODULE__, opts, name: name)
-    end
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
   @impl true
@@ -34,17 +30,43 @@ defmodule Honeybadger.EventsSampler do
     {:ok, state}
   end
 
-  def sample?(hash_value \\ nil, server \\ __MODULE__) do
-    if Honeybadger.get_env(:insights_sample_rate) == @fully_sampled_rate do
+  @doc """
+  Determines if an event should be sampled based on its hash value.
+
+  ## Options
+    * `:sample_rate` - Override the default sample rate from the server state
+    * `:hash_value` - The hash value to use for sampling. If not provided, a random value is used.
+    * `:server` - Specify the GenServer to use (default: `__MODULE__`)
+
+  ## Examples
+      iex> Sampler.sample?()
+      true
+
+      iex> Sampler.sample?(sample_rate: 1)
+      false
+
+      iex> Sampler.sample?(hash_value: "abc-123")
+      false
+  """
+  @spec sample?(Keyword.t()) :: boolean()
+  def sample?(opts \\ []) do
+    server = Keyword.get(opts, :server, __MODULE__)
+
+    if sampling_at_full_rate?(opts) do
       true
     else
-      GenServer.call(server, {:sample?, hash_value})
+      GenServer.call(server, {:sample?, opts})
     end
   end
 
   @impl true
-  def handle_call({:sample?, hash_value}, _from, state) do
-    decision = do_sample?(hash_value, state.sample_rate)
+  def handle_call({:sample?, opts}, _from, state) do
+    decision =
+      do_sample?(
+        Keyword.get(opts, :hash_value),
+        Keyword.get(opts, :sample_rate, state.sample_rate)
+      )
+
     # Increment the count of sampled or ignored events
     count_key = if decision, do: :sample_count, else: :ignore_count
     state = update_in(state, [count_key], &(&1 + 1))
@@ -62,6 +84,11 @@ defmodule Honeybadger.EventsSampler do
     schedule_report(state.sampled_log_interval)
 
     {:noreply, %{state | sample_count: 0, ignore_count: 0}}
+  end
+
+  defp sampling_at_full_rate?(opts) when is_list(opts) do
+    sample_rate = Keyword.get(opts, :sample_rate, Honeybadger.get_env(:insights_sample_rate))
+    sample_rate == @fully_sampled_rate
   end
 
   # Use random sampling when no hash value is provided

--- a/test/honeybadger/events_sampler_test.exs
+++ b/test/honeybadger/events_sampler_test.exs
@@ -31,7 +31,7 @@ defmodule Honeybadger.EventsSamplerTest do
         capture_log(fn ->
           EventsSampler.sample?(hash_value: "trace-1", server: sampler)
           EventsSampler.sample?(hash_value: "trace-2", server: sampler)
-          Process.sleep(500)
+          Process.sleep(1000)
         end)
 
       assert log =~ ~r/\[Honeybadger\] Sampled \d events \(of 2 total events\)/
@@ -47,7 +47,7 @@ defmodule Honeybadger.EventsSamplerTest do
           EventsSampler.sample?(server: sampler)
           EventsSampler.sample?(server: sampler)
           EventsSampler.sample?(server: sampler)
-          Process.sleep(500)
+          Process.sleep(1000)
         end)
 
       assert log =~ ~r/\[Honeybadger\] Sampled \d events \(of 3 total events\)/

--- a/test/honeybadger/events_sampler_test.exs
+++ b/test/honeybadger/events_sampler_test.exs
@@ -54,6 +54,14 @@ defmodule Honeybadger.EventsSamplerTest do
     end)
   end
 
+  test "handles nil sample_rate" do
+    with_config([insights_sample_rate: 0], fn ->
+      {:ok, sampler} = start_sampler()
+      refute EventsSampler.sample?(sample_rate: nil, server: sampler)
+      refute EventsSampler.sample?(hash_value: "asdf", sample_rate: nil, server: sampler)
+    end)
+  end
+
   test "respects custom sample rate in opts" do
     with_config([insights_sample_rate: 50], fn ->
       {:ok, sampler} = start_sampler()

--- a/test/honeybadger/events_worker_test.exs
+++ b/test/honeybadger/events_worker_test.exs
@@ -241,7 +241,7 @@ defmodule Honeybadger.EventsWorkerTest do
       change_behavior.(:ok)
 
       # Should send both batches after throttle period
-      assert_receive {:events_sent, ^first_batch}, 350
+      assert_receive {:events_sent, ^first_batch}, 500
       assert_receive {:events_sent, ^second_batch}, 50
 
       GenServer.stop(pid)

--- a/test/honeybadger_test.exs
+++ b/test/honeybadger_test.exs
@@ -572,5 +572,42 @@ defmodule HoneybadgerTest do
       assert data["key"] == "value"
       assert data["user_id"] == 456
     end
+
+    test "samples with custom rate" do
+      restart_with_config(
+        exclude_envs: [],
+        events_worker_enabled: false,
+        insights_sample_rate: 100
+      )
+
+      Honeybadger.event(%{event_type: "test_event", key: "value", _hb: %{sample_rate: 0}})
+
+      refute_receive {:api_request, _data}
+    end
+
+    test "samples with custom overriding global lower rate" do
+      restart_with_config(
+        exclude_envs: [],
+        events_worker_enabled: false,
+        insights_sample_rate: 0
+      )
+
+      Honeybadger.event(%{event_type: "test_event", key: "value", _hb: %{sample_rate: 100}})
+
+      assert_receive {:api_request, _data}
+    end
+
+    test "samples with custom rate in context" do
+      restart_with_config(
+        exclude_envs: [],
+        events_worker_enabled: false,
+        insights_sample_rate: 100
+      )
+
+      Honeybadger.event_context(%{_hb: %{sample_rate: 0}})
+      Honeybadger.event(%{event_type: "test_event", key: "value"})
+
+      refute_receive {:api_request, _data}
+    end
   end
 end


### PR DESCRIPTION
This allows for the sample rate to be set within the payload of the event, in a new metadata map:

```elixir
Honeybadger.event("user_created", %{
  user_id: user.id,
  _hb: %{sample_rate: 100}
})
```

There are a few changes that I made to enable this:

* The `Honeybadger.EventsSampler` is now started even if the global sample rate is 100, as I don't know if a user will then send a different sample rate with the event.
* The evaluation was reordered, so a filter could add the sample rate to the payload
* I am stripping the metadata map before sending the event