### PR TITLE
feat: derive _component from stacktrace for better error grouping

### DIFF
--- a/lib/honeybadger/component_deriver.ex
+++ b/lib/honeybadger/component_deriver.ex
@@ -1,0 +1,146 @@
+defmodule Honeybadger.ComponentDeriver do
+  @moduledoc """
+  Derives a component name from a stacktrace for better error grouping.
+
+  When errors occur outside of web requests (e.g., in background jobs, GenServers,
+  or Tasks), there's no Phoenix controller to use as the component. This module
+  analyzes the stacktrace to find a meaningful "origin" module that can serve as
+  the component for fingerprinting purposes.
+
+  The Honeybadger API uses the component field (along with exception class and
+  the first application backtrace frame) to group errors. Without a component,
+  errors with similar stacktraces may be incorrectly grouped together.
+
+  ## How It Works
+
+  The deriver walks through the stacktrace looking for the first frame that:
+  1. Belongs to the configured application (`:app` config)
+  2. Is not in the list of skipped "infrastructure" modules
+
+  Infrastructure modules are things like `Ecto.Repo`, `Ecto.Changeset`, etc. that
+  appear in many stacktraces but don't indicate where the error actually originated.
+
+  ## Configuration
+
+  You can customize which modules are skipped:
+
+      config :honeybadger,
+        component_deriver_skip_modules: [
+          Ecto.Repo,
+          Ecto.Changeset,
+          MyApp.CustomInfraModule
+        ]
+
+  The default skip list includes common Ecto and database-related modules.
+  """
+
+  alias Honeybadger.Utils
+
+  @default_skip_patterns [
+    # Ecto infrastructure - these appear in most DB error stacktraces
+    ~r/^Ecto\.Repo/,
+    ~r/^Ecto\.Changeset/,
+    ~r/^Ecto\.Adapters/,
+    ~r/^Ecto\.Multi/,
+    ~r/^Ecto\.Query/,
+    # Database drivers
+    ~r/^Postgrex/,
+    ~r/^Mariaex/,
+    ~r/^MyXQL/,
+    ~r/^Exqlite/,
+    ~r/^DBConnection/,
+    # Telemetry
+    ~r/^Telemetry/,
+    ~r/^:telemetry/
+  ]
+
+  @doc """
+  Derives a component name from a stacktrace.
+
+  Returns the module name as a string if a suitable component is found,
+  or `nil` if no suitable module could be determined.
+
+  ## Parameters
+
+    * `stacktrace` - An Elixir stacktrace (list of stack frames)
+    * `opts` - Optional keyword list with:
+      * `:app` - The application atom to match against (defaults to Honeybadger config)
+      * `:skip_patterns` - List of regex patterns for modules to skip
+
+  ## Examples
+
+      iex> stacktrace = [
+      ...>   {MyApp.Users, :create, 2, [file: 'lib/my_app/users.ex', line: 42]},
+      ...>   {Ecto.Repo, :insert, 2, [file: 'lib/ecto/repo.ex', line: 100]}
+      ...> ]
+      iex> Honeybadger.ComponentDeriver.derive(stacktrace)
+      "MyApp.Users"
+
+  """
+  @spec derive(Exception.stacktrace(), keyword()) :: String.t() | nil
+  def derive(stacktrace, opts \\ [])
+
+  def derive([], _opts), do: nil
+
+  def derive(stacktrace, opts) when is_list(stacktrace) do
+    app = Keyword.get_lazy(opts, :app, fn -> Honeybadger.get_env(:app) end)
+    skip_patterns = Keyword.get(opts, :skip_patterns, skip_patterns())
+
+    stacktrace
+    |> Enum.find(&suitable_frame?(&1, app, skip_patterns))
+    |> frame_to_component()
+  end
+
+  @doc """
+  Returns the list of module patterns to skip when deriving components.
+
+  This combines the default patterns with any user-configured patterns.
+  """
+  @spec skip_patterns() :: [Regex.t()]
+  def skip_patterns do
+    user_patterns =
+      Application.get_env(:honeybadger, :component_deriver_skip_patterns, [])
+      |> Enum.map(&pattern_to_regex/1)
+
+    @default_skip_patterns ++ user_patterns
+  end
+
+  # Convert user-provided patterns to regex
+  defp pattern_to_regex(%Regex{} = regex), do: regex
+  defp pattern_to_regex(module) when is_atom(module), do: module_to_regex(module)
+  defp pattern_to_regex(string) when is_binary(string), do: Regex.compile!("^#{Regex.escape(string)}")
+
+  defp module_to_regex(module) do
+    module
+    |> Utils.module_to_string()
+    |> Regex.escape()
+    |> then(&Regex.compile!("^#{&1}"))
+  end
+
+  # Check if a stack frame is suitable for use as a component
+  defp suitable_frame?({module, _fun, _arity_or_args, _location}, app, skip_patterns) do
+    app_matches?(module, app) && !skipped?(module, skip_patterns)
+  end
+
+  defp suitable_frame?(_frame, _app, _skip_patterns), do: false
+
+  # Check if the module belongs to the configured application
+  defp app_matches?(_module, nil), do: false
+
+  defp app_matches?(module, app) do
+    Application.get_application(module) == app
+  end
+
+  # Check if the module matches any skip patterns
+  defp skipped?(module, skip_patterns) do
+    module_string = Utils.module_to_string(module)
+    Enum.any?(skip_patterns, &Regex.match?(&1, module_string))
+  end
+
+  # Extract the component name from a stack frame
+  defp frame_to_component(nil), do: nil
+
+  defp frame_to_component({module, _fun, _arity_or_args, _location}) do
+    Utils.module_to_string(module)
+  end
+end

--- a/lib/honeybadger/component_deriver.ex
+++ b/lib/honeybadger/component_deriver.ex
@@ -110,7 +110,9 @@ defmodule Honeybadger.ComponentDeriver do
   # Convert user-provided patterns to regex
   defp pattern_to_regex(%Regex{} = regex), do: regex
   defp pattern_to_regex(module) when is_atom(module), do: module_to_regex(module)
-  defp pattern_to_regex(string) when is_binary(string), do: Regex.compile!("^#{Regex.escape(string)}")
+
+  defp pattern_to_regex(string) when is_binary(string),
+    do: Regex.compile!("^#{Regex.escape(string)}")
 
   defp module_to_regex(module) do
     module

--- a/lib/honeybadger/component_deriver.ex
+++ b/lib/honeybadger/component_deriver.ex
@@ -38,24 +38,6 @@ defmodule Honeybadger.ComponentDeriver do
 
   alias Honeybadger.Utils
 
-  @default_skip_patterns [
-    # Ecto infrastructure - these appear in most DB error stacktraces
-    ~r/^Ecto\.Repo/,
-    ~r/^Ecto\.Changeset/,
-    ~r/^Ecto\.Adapters/,
-    ~r/^Ecto\.Multi/,
-    ~r/^Ecto\.Query/,
-    # Database drivers
-    ~r/^Postgrex/,
-    ~r/^Mariaex/,
-    ~r/^MyXQL/,
-    ~r/^Exqlite/,
-    ~r/^DBConnection/,
-    # Telemetry
-    ~r/^Telemetry/,
-    ~r/^:telemetry/
-  ]
-
   @doc """
   Derives a component name from a stacktrace.
 
@@ -104,7 +86,27 @@ defmodule Honeybadger.ComponentDeriver do
       Application.get_env(:honeybadger, :component_deriver_skip_patterns, [])
       |> Enum.map(&pattern_to_regex/1)
 
-    @default_skip_patterns ++ user_patterns
+    default_skip_patterns() ++ user_patterns
+  end
+
+  defp default_skip_patterns do
+    [
+      # Ecto infrastructure - these appear in most DB error stacktraces
+      ~r/^Ecto\.Repo/,
+      ~r/^Ecto\.Changeset/,
+      ~r/^Ecto\.Adapters/,
+      ~r/^Ecto\.Multi/,
+      ~r/^Ecto\.Query/,
+      # Database drivers
+      ~r/^Postgrex/,
+      ~r/^Mariaex/,
+      ~r/^MyXQL/,
+      ~r/^Exqlite/,
+      ~r/^DBConnection/,
+      # Telemetry
+      ~r/^Telemetry/,
+      ~r/^:telemetry/
+    ]
   end
 
   # Convert user-provided patterns to regex

--- a/lib/honeybadger/component_deriver.ex
+++ b/lib/honeybadger/component_deriver.ex
@@ -25,13 +25,15 @@ defmodule Honeybadger.ComponentDeriver do
   You can customize which modules are skipped:
 
       config :honeybadger,
-        component_deriver_skip_modules: [
+        component_deriver_skip_patterns: [
           Ecto.Repo,
           Ecto.Changeset,
-          MyApp.CustomInfraModule
+          MyApp.CustomInfraModule,
+          ~r/^MyApp\\.Internal/
         ]
 
-  The default skip list includes common Ecto and database-related modules.
+  Patterns can be module atoms, strings, or regexes. The default skip list
+  includes common Ecto and database-related modules.
   """
 
   alias Honeybadger.Utils

--- a/lib/honeybadger/component_deriver.ex
+++ b/lib/honeybadger/component_deriver.ex
@@ -110,17 +110,18 @@ defmodule Honeybadger.ComponentDeriver do
   # Convert user-provided patterns to regex
   defp pattern_to_regex(%Regex{} = regex), do: regex
   defp pattern_to_regex(module) when is_atom(module), do: module_to_regex(module)
+  defp pattern_to_regex(string) when is_binary(string), do: name_to_regex(string)
 
-  defp pattern_to_regex(string) when is_binary(string),
-    do: Regex.compile!("^#{Regex.escape(string)}")
-
-  # Match the module itself or its submodules, but not other modules that
-  # merely share the name as a prefix (e.g. MyApp.Repo vs MyApp.Reports).
   defp module_to_regex(module) do
     module
     |> Utils.module_to_string()
-    |> Regex.escape()
-    |> then(&Regex.compile!("^#{&1}(\\.|$)"))
+    |> name_to_regex()
+  end
+
+  # Match the named module itself or its submodules, but not other modules
+  # that merely share the name as a prefix (e.g. MyApp.Repo vs MyApp.Reports).
+  defp name_to_regex(name) do
+    Regex.compile!("^#{Regex.escape(name)}(\\.|$)")
   end
 
   # Check if a stack frame is suitable for use as a component

--- a/lib/honeybadger/component_deriver.ex
+++ b/lib/honeybadger/component_deriver.ex
@@ -15,25 +15,28 @@ defmodule Honeybadger.ComponentDeriver do
 
   The deriver walks through the stacktrace looking for the first frame that:
   1. Belongs to the configured application (`:app` config)
-  2. Is not in the list of skipped "infrastructure" modules
+  2. Is not in the list of skipped modules
 
-  Infrastructure modules are things like `Ecto.Repo`, `Ecto.Changeset`, etc. that
-  appear in many stacktraces but don't indicate where the error actually originated.
+  The app ownership check already excludes library frames (`Ecto.Repo`,
+  `Postgrex`, etc.), since those modules belong to their own OTP applications.
+  The skip list exists for modules that *do* belong to the app but don't
+  indicate where an error originated — most notably the app's Ecto repo
+  (e.g. `MyApp.Repo`), which appears in every database error's stacktrace.
+  Repo modules are skipped automatically by reading the app's `:ecto_repos`
+  configuration.
 
   ## Configuration
 
-  You can customize which modules are skipped:
+  You can skip additional modules:
 
       config :honeybadger,
         component_deriver_skip_patterns: [
-          Ecto.Repo,
-          Ecto.Changeset,
           MyApp.CustomInfraModule,
-          ~r/^MyApp\\.Internal/
+          ~r/^MyApp\\.Internal/,
+          "MyApp.Utilities"
         ]
 
-  Patterns can be module atoms, strings, or regexes. The default skip list
-  includes common Ecto and database-related modules.
+  Patterns can be module atoms, strings, or regexes.
   """
 
   alias Honeybadger.Utils
@@ -68,7 +71,7 @@ defmodule Honeybadger.ComponentDeriver do
 
   def derive(stacktrace, opts) when is_list(stacktrace) do
     app = Keyword.get_lazy(opts, :app, fn -> Honeybadger.get_env(:app) end)
-    skip_patterns = Keyword.get(opts, :skip_patterns, skip_patterns())
+    skip_patterns = Keyword.get_lazy(opts, :skip_patterns, fn -> skip_patterns(app) end)
 
     stacktrace
     |> Enum.find(&suitable_frame?(&1, app, skip_patterns))
@@ -78,35 +81,30 @@ defmodule Honeybadger.ComponentDeriver do
   @doc """
   Returns the list of module patterns to skip when deriving components.
 
-  This combines the default patterns with any user-configured patterns.
+  This combines the app's `:ecto_repos` modules with any user-configured
+  patterns.
   """
-  @spec skip_patterns() :: [Regex.t()]
-  def skip_patterns do
-    user_patterns =
-      Application.get_env(:honeybadger, :component_deriver_skip_patterns, [])
-      |> Enum.map(&pattern_to_regex/1)
-
-    default_skip_patterns() ++ user_patterns
+  @spec skip_patterns(atom() | nil) :: [Regex.t()]
+  def skip_patterns(app \\ Honeybadger.get_env(:app)) do
+    ecto_repo_patterns(app) ++ user_patterns()
   end
 
-  defp default_skip_patterns do
-    [
-      # Ecto infrastructure - these appear in most DB error stacktraces
-      ~r/^Ecto\.Repo/,
-      ~r/^Ecto\.Changeset/,
-      ~r/^Ecto\.Adapters/,
-      ~r/^Ecto\.Multi/,
-      ~r/^Ecto\.Query/,
-      # Database drivers
-      ~r/^Postgrex/,
-      ~r/^Mariaex/,
-      ~r/^MyXQL/,
-      ~r/^Exqlite/,
-      ~r/^DBConnection/,
-      # Telemetry
-      ~r/^Telemetry/,
-      ~r/^:telemetry/
-    ]
+  # The app's Ecto repos appear in every database error's stacktrace but don't
+  # indicate where the error originated, so they'd otherwise dominate as the
+  # derived component.
+  defp ecto_repo_patterns(nil), do: []
+
+  defp ecto_repo_patterns(app) do
+    app
+    |> Application.get_env(:ecto_repos, [])
+    |> Enum.filter(&is_atom/1)
+    |> Enum.map(&module_to_regex/1)
+  end
+
+  defp user_patterns do
+    :honeybadger
+    |> Application.get_env(:component_deriver_skip_patterns, [])
+    |> Enum.map(&pattern_to_regex/1)
   end
 
   # Convert user-provided patterns to regex

--- a/lib/honeybadger/component_deriver.ex
+++ b/lib/honeybadger/component_deriver.ex
@@ -114,11 +114,13 @@ defmodule Honeybadger.ComponentDeriver do
   defp pattern_to_regex(string) when is_binary(string),
     do: Regex.compile!("^#{Regex.escape(string)}")
 
+  # Match the module itself or its submodules, but not other modules that
+  # merely share the name as a prefix (e.g. MyApp.Repo vs MyApp.Reports).
   defp module_to_regex(module) do
     module
     |> Utils.module_to_string()
     |> Regex.escape()
-    |> then(&Regex.compile!("^#{&1}"))
+    |> then(&Regex.compile!("^#{&1}(\\.|$)"))
   end
 
   # Check if a stack frame is suitable for use as a component

--- a/test/honeybadger/component_deriver_test.exs
+++ b/test/honeybadger/component_deriver_test.exs
@@ -1,0 +1,159 @@
+defmodule Honeybadger.ComponentDeriverTest do
+  use Honeybadger.Case, async: true
+
+  alias Honeybadger.ComponentDeriver
+
+  # Use real Honeybadger modules for testing since Application.get_application/1
+  # only works for modules that are part of a loaded OTP application.
+  # Honeybadger.Notice, Honeybadger.Backtrace, etc. are part of :honeybadger app.
+
+  describe "derive/2" do
+    test "returns nil for empty stacktrace" do
+      assert ComponentDeriver.derive([]) == nil
+    end
+
+    test "returns the first app module from stacktrace" do
+      # Use real Honeybadger modules which are part of the :honeybadger app
+      stacktrace = [
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]},
+        {Honeybadger.Backtrace, :from_stacktrace, 1, [file: ~c"lib/honeybadger/backtrace.ex", line: 10]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == "Honeybadger.Notice"
+      end)
+    end
+
+    test "skips Ecto.Repo modules" do
+      stacktrace = [
+        {Ecto.Repo, :insert, 2, [file: ~c"lib/ecto/repo.ex", line: 100]},
+        {Ecto.Repo.Queryable, :all, 3, [file: ~c"lib/ecto/repo/queryable.ex", line: 50]},
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == "Honeybadger.Notice"
+      end)
+    end
+
+    test "skips Ecto.Changeset modules" do
+      stacktrace = [
+        {Ecto.Changeset, :apply_action!, 2, [file: ~c"lib/ecto/changeset.ex", line: 200]},
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == "Honeybadger.Notice"
+      end)
+    end
+
+    test "skips Postgrex modules" do
+      stacktrace = [
+        {Postgrex.Protocol, :recv_message, 2, [file: ~c"lib/postgrex/protocol.ex", line: 100]},
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == "Honeybadger.Notice"
+      end)
+    end
+
+    test "skips DBConnection modules" do
+      stacktrace = [
+        {DBConnection, :execute, 4, [file: ~c"lib/db_connection.ex", line: 100]},
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == "Honeybadger.Notice"
+      end)
+    end
+
+    test "returns nil if no suitable module found" do
+      stacktrace = [
+        {Ecto.Repo, :insert, 2, [file: ~c"lib/ecto/repo.ex", line: 100]},
+        {Postgrex.Protocol, :recv_message, 2, [file: ~c"lib/postgrex/protocol.ex", line: 50]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == nil
+      end)
+    end
+
+    test "only considers modules from the configured app" do
+      # Ecto.Changeset is from :ecto app, not :honeybadger, so should be skipped
+      # for app matching (not just pattern matching)
+      stacktrace = [
+        {Ecto.Query, :from, 2, [file: ~c"lib/ecto/query.ex", line: 10]},
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        # Ecto.Query is from :ecto app, not :honeybadger, so should fall through
+        assert result == "Honeybadger.Notice"
+      end)
+    end
+
+    test "accepts app option override" do
+      stacktrace = [
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
+      ]
+
+      # Use a non-existent app so nothing matches
+      result = ComponentDeriver.derive(stacktrace, app: :nonexistent_app)
+      assert result == nil
+    end
+
+    test "handles malformed stack frames gracefully" do
+      stacktrace = [
+        {:not_a_module, :foo, 1, []},
+        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
+      ]
+
+      with_config([app: :honeybadger], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == "Honeybadger.Notice"
+      end)
+    end
+  end
+
+  describe "skip_patterns/0" do
+    test "includes default patterns" do
+      patterns = ComponentDeriver.skip_patterns()
+      assert Enum.any?(patterns, &Regex.match?(&1, "Ecto.Repo"))
+      assert Enum.any?(patterns, &Regex.match?(&1, "Ecto.Repo.Queryable"))
+      assert Enum.any?(patterns, &Regex.match?(&1, "Ecto.Changeset"))
+      assert Enum.any?(patterns, &Regex.match?(&1, "Postgrex.Protocol"))
+      assert Enum.any?(patterns, &Regex.match?(&1, "DBConnection"))
+    end
+
+    test "includes user-configured patterns" do
+      with_config([component_deriver_skip_patterns: [MyApp.CustomInfra]], fn ->
+        patterns = ComponentDeriver.skip_patterns()
+        # The module atom MyApp.CustomInfra becomes "MyApp.CustomInfra" string pattern
+        assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.CustomInfra"))
+      end)
+    end
+
+    test "accepts regex patterns in config" do
+      with_config([component_deriver_skip_patterns: [~r/^MyApp\.Internal/]], fn ->
+        patterns = ComponentDeriver.skip_patterns()
+        assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Internal.Something"))
+      end)
+    end
+
+    test "accepts string patterns in config" do
+      with_config([component_deriver_skip_patterns: ["MyApp.Internal"]], fn ->
+        patterns = ComponentDeriver.skip_patterns()
+        assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Internal"))
+      end)
+    end
+  end
+end

--- a/test/honeybadger/component_deriver_test.exs
+++ b/test/honeybadger/component_deriver_test.exs
@@ -16,7 +16,8 @@ defmodule Honeybadger.ComponentDeriverTest do
       # Use real Honeybadger modules which are part of the :honeybadger app
       stacktrace = [
         {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]},
-        {Honeybadger.Backtrace, :from_stacktrace, 1, [file: ~c"lib/honeybadger/backtrace.ex", line: 10]}
+        {Honeybadger.Backtrace, :from_stacktrace, 1,
+         [file: ~c"lib/honeybadger/backtrace.ex", line: 10]}
       ]
 
       with_config([app: :honeybadger], fn ->

--- a/test/honeybadger/component_deriver_test.exs
+++ b/test/honeybadger/component_deriver_test.exs
@@ -157,6 +157,8 @@ defmodule Honeybadger.ComponentDeriverTest do
       with_config([component_deriver_skip_patterns: ["MyApp.Internal"]], fn ->
         patterns = ComponentDeriver.skip_patterns()
         assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Internal"))
+        assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Internal.Cache"))
+        refute Enum.any?(patterns, &Regex.match?(&1, "MyApp.InternalStuff"))
       end)
     end
   end

--- a/test/honeybadger/component_deriver_test.exs
+++ b/test/honeybadger/component_deriver_test.exs
@@ -1,5 +1,8 @@
 defmodule Honeybadger.ComponentDeriverTest do
-  use Honeybadger.Case, async: true
+  # Not async: these tests set the global :app config via with_config, which
+  # would race with async tests in other modules that read it (e.g. Backtrace's
+  # context depends on it).
+  use Honeybadger.Case, async: false
 
   alias Honeybadger.ComponentDeriver
 
@@ -124,6 +127,14 @@ defmodule Honeybadger.ComponentDeriverTest do
         patterns = ComponentDeriver.skip_patterns()
         assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Repo"))
         assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Repo.Preloader"))
+      end)
+    end
+
+    test "repo patterns do not match modules sharing the repo's name as a prefix" do
+      with_config([app: :honeybadger, ecto_repos: [MyApp.Repo]], fn ->
+        patterns = ComponentDeriver.skip_patterns()
+        refute Enum.any?(patterns, &Regex.match?(&1, "MyApp.Reports"))
+        refute Enum.any?(patterns, &Regex.match?(&1, "MyApp.Repository"))
       end)
     end
 

--- a/test/honeybadger/component_deriver_test.exs
+++ b/test/honeybadger/component_deriver_test.exs
@@ -26,45 +26,11 @@ defmodule Honeybadger.ComponentDeriverTest do
       end)
     end
 
-    test "skips Ecto.Repo modules" do
+    test "skips library modules that don't belong to the app" do
       stacktrace = [
         {Ecto.Repo, :insert, 2, [file: ~c"lib/ecto/repo.ex", line: 100]},
-        {Ecto.Repo.Queryable, :all, 3, [file: ~c"lib/ecto/repo/queryable.ex", line: 50]},
-        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
-      ]
-
-      with_config([app: :honeybadger], fn ->
-        result = ComponentDeriver.derive(stacktrace)
-        assert result == "Honeybadger.Notice"
-      end)
-    end
-
-    test "skips Ecto.Changeset modules" do
-      stacktrace = [
         {Ecto.Changeset, :apply_action!, 2, [file: ~c"lib/ecto/changeset.ex", line: 200]},
-        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
-      ]
-
-      with_config([app: :honeybadger], fn ->
-        result = ComponentDeriver.derive(stacktrace)
-        assert result == "Honeybadger.Notice"
-      end)
-    end
-
-    test "skips Postgrex modules" do
-      stacktrace = [
         {Postgrex.Protocol, :recv_message, 2, [file: ~c"lib/postgrex/protocol.ex", line: 100]},
-        {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
-      ]
-
-      with_config([app: :honeybadger], fn ->
-        result = ComponentDeriver.derive(stacktrace)
-        assert result == "Honeybadger.Notice"
-      end)
-    end
-
-    test "skips DBConnection modules" do
-      stacktrace = [
         {DBConnection, :execute, 4, [file: ~c"lib/db_connection.ex", line: 100]},
         {Honeybadger.Notice, :new, 4, [file: ~c"lib/honeybadger/notice.ex", line: 42]}
       ]
@@ -72,6 +38,22 @@ defmodule Honeybadger.ComponentDeriverTest do
       with_config([app: :honeybadger], fn ->
         result = ComponentDeriver.derive(stacktrace)
         assert result == "Honeybadger.Notice"
+      end)
+    end
+
+    test "skips modules configured in :ecto_repos for the app" do
+      # Honeybadger.Notice stands in for MyApp.Repo here: a module owned by the
+      # app that appears in Ecto error stacktraces but doesn't indicate where
+      # the error originated.
+      stacktrace = [
+        {Honeybadger.Notice, :insert, 2, [file: ~c"lib/honeybadger/notice.ex", line: 100]},
+        {Honeybadger.Backtrace, :from_stacktrace, 1,
+         [file: ~c"lib/honeybadger/backtrace.ex", line: 10]}
+      ]
+
+      with_config([app: :honeybadger, ecto_repos: [Honeybadger.Notice]], fn ->
+        result = ComponentDeriver.derive(stacktrace)
+        assert result == "Honeybadger.Backtrace"
       end)
     end
 
@@ -125,14 +107,24 @@ defmodule Honeybadger.ComponentDeriverTest do
     end
   end
 
-  describe "skip_patterns/0" do
-    test "includes default patterns" do
-      patterns = ComponentDeriver.skip_patterns()
-      assert Enum.any?(patterns, &Regex.match?(&1, "Ecto.Repo"))
-      assert Enum.any?(patterns, &Regex.match?(&1, "Ecto.Repo.Queryable"))
-      assert Enum.any?(patterns, &Regex.match?(&1, "Ecto.Changeset"))
-      assert Enum.any?(patterns, &Regex.match?(&1, "Postgrex.Protocol"))
-      assert Enum.any?(patterns, &Regex.match?(&1, "DBConnection"))
+  describe "skip_patterns/1" do
+    test "has no built-in library patterns" do
+      # Library modules (Ecto, Postgrex, etc.) are already excluded by the app
+      # ownership check, so there are no default skip patterns for them.
+      with_config([app: :honeybadger], fn ->
+        patterns = ComponentDeriver.skip_patterns()
+        refute Enum.any?(patterns, &Regex.match?(&1, "Ecto.Repo"))
+        refute Enum.any?(patterns, &Regex.match?(&1, "Postgrex.Protocol"))
+        refute Enum.any?(patterns, &Regex.match?(&1, "DBConnection"))
+      end)
+    end
+
+    test "includes modules from the app's :ecto_repos config" do
+      with_config([app: :honeybadger, ecto_repos: [MyApp.Repo]], fn ->
+        patterns = ComponentDeriver.skip_patterns()
+        assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Repo"))
+        assert Enum.any?(patterns, &Regex.match?(&1, "MyApp.Repo.Preloader"))
+      end)
     end
 
     test "includes user-configured patterns" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -37,7 +37,7 @@ defmodule Honeybadger.Case do
 
       fun.()
     after
-      put_all_env(original)
+      restore_env(opts, original)
     end
   end
 
@@ -48,7 +48,7 @@ defmodule Honeybadger.Case do
     put_all_env(opts)
 
     on_exit(fn ->
-      put_all_env(original)
+      restore_env(opts, original)
     end)
 
     :ok = Application.ensure_started(:honeybadger)
@@ -70,6 +70,19 @@ defmodule Honeybadger.Case do
 
   defp take_original_env(opts) do
     Keyword.take(Application.get_all_env(:honeybadger), Keyword.keys(opts))
+  end
+
+  # Restore the original values, deleting any keys that weren't set before so
+  # temporary config can't leak into the rest of the run.
+  defp restore_env(opts, original) do
+    opts
+    |> Keyword.keys()
+    |> Enum.each(fn key ->
+      case Keyword.fetch(original, key) do
+        {:ok, val} -> Application.put_env(:honeybadger, key, val)
+        :error -> Application.delete_env(:honeybadger, key)
+      end
+    end)
   end
 
   defp put_all_env(opts) do


### PR DESCRIPTION
## Problem

Jim reported (in #668) that different `Ecto.ConstraintError` exceptions from different locations in their application were being grouped together as the same error in Honeybadger. This caused issues with integrations (like Shortcut) where resolved issues would unexpectedly reopen.

### Root Cause

Honeybadger's fingerprinting algorithm uses three fields to group errors:
- Exception class (e.g., `"Ecto.ConstraintError"`)
- Component (e.g., controller name)
- First application backtrace frame (`file:method:line`)

For non-web errors (background jobs, GenServers, Tasks), there's no Phoenix controller, so `component` is empty. When two different constraint errors both flow through the same `Ecto.Repo` module, they can end up with identical fingerprints:

```
hexdigest("Ecto.ConstraintError", "", "lib/my_app/repo.ex:insert:100")
```

Even though they originate from completely different parts of the application (e.g., `MyApp.Users` vs `MyApp.Orders`).

## Solution

This PR automatically derives `_component` from the stacktrace for non-web errors. The `ComponentDeriver` module:

1. Walks through stack frames looking for modules belonging to the configured `:app` — this inherently excludes library frames (`Ecto.Repo`, `Postgrex`, `DBConnection`, etc.), since those modules belong to their own OTP applications
2. Automatically skips the app's own Ecto repo modules (read from the app's `:ecto_repos` config), since repo frames appear in database error stacktraces without indicating the error's true origin
3. Sets the first suitable module as `_component` in the context

The Honeybadger API parser already looks for `_component` in the context (before falling back to `request.component`), so this provides differentiated fingerprints:

```
hexdigest("Ecto.ConstraintError", "MyApp.Users", "lib/my_app/repo.ex:insert:100")
hexdigest("Ecto.ConstraintError", "MyApp.Orders", "lib/my_app/repo.ex:insert:100")
```

### Configuration

The app's Ecto repos are skipped automatically via its `:ecto_repos` config. Users can skip additional modules:

```elixir
config :honeybadger,
  component_deriver_skip_patterns: [
    MyApp.CustomInfraModule,      # atom
    ~r/^MyApp\.Internal/,         # regex
    "MyApp.Utilities"             # string
  ]
```

Atom and string patterns match the named module and its submodules (but not other modules that merely share the name as a prefix); regexes match however they're written.

## Workaround (for users on older versions)

Users who can't upgrade immediately can work around this by explicitly setting context before operations that might fail:

```elixir
Honeybadger.context(_component: "MyApp.Users", _action: "create")
```

Or by implementing a [custom fingerprint adapter](https://hexdocs.pm/honeybadger/Honeybadger.FingerprintAdapter.html):

```elixir
config :honeybadger, fingerprint_adapter: MyApp.FingerprintAdapter
```

## Test plan

- [x] Added unit tests for `ComponentDeriver` module (14 tests)
- [x] Added integration tests in `NoticeTest` (5 tests)
- [x] Verified existing tests still pass
- [x] Tested that component is derived correctly from stacktraces
- [x] Tested that existing plug_env components are not overridden
- [x] Tested that user-set `_component` in context is respected

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error notices now automatically identify the application component responsible for an error when no component is provided.
  * Component detection uses relevant stacktrace information while excluding framework and configured repository modules.

* **Bug Fixes**
  * Explicit component values and request environment settings continue to take precedence over inferred values.
  * Empty or malformed stacktraces are handled gracefully without disrupting notice creation.
  * Temporary configuration is restored cleanly, preventing settings from leaking between operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
