### PR TITLE
feat: persist socket_id in EventContext during LiveView mount

### DIFF
--- a/lib/honeybadger/insights/live_view.ex
+++ b/lib/honeybadger/insights/live_view.ex
@@ -61,6 +61,10 @@ defmodule Honeybadger.Insights.LiveView do
       Honeybadger.Utils.rand_id()
     end)
 
+    Honeybadger.EventContext.put_new(:socket_id, fn ->
+      extract_socket_id(metadata)
+    end)
+
     if event in get_insights_config(:telemetry_events, @telemetry_events) do
       handle_event_impl(event, measurements, metadata, opts)
     end

--- a/test/honeybadger/insights/live_view_test.exs
+++ b/test/honeybadger/insights/live_view_test.exs
@@ -56,4 +56,83 @@ defmodule Honeybadger.Insights.LiveViewTest do
       assert event["assigns"] == nil
     end
   end
+
+  describe "mount start handler" do
+    test "sets socket_id in event context from socket" do
+      :telemetry.execute(
+        [:phoenix, :live_view, :mount, :start],
+        %{},
+        %{
+          socket: %{
+            id: "phx-Fmount123",
+            view: MyApp.DashboardLive,
+            assigns: %{}
+          }
+        }
+      )
+
+      assert Honeybadger.EventContext.get(:socket_id) == "phx-Fmount123"
+    end
+
+    test "sets socket_id in event context from socket_id key" do
+      :telemetry.execute(
+        [:phoenix, :live_view, :mount, :start],
+        %{},
+        %{
+          socket_id: "phx-Gtop456"
+        }
+      )
+
+      assert Honeybadger.EventContext.get(:socket_id) == "phx-Gtop456"
+    end
+
+    test "socket_id propagates to subsequent events" do
+      :telemetry.execute(
+        [:phoenix, :live_view, :mount, :start],
+        %{},
+        %{
+          socket: %{
+            id: "phx-Hprop789",
+            view: MyApp.DashboardLive,
+            assigns: %{}
+          }
+        }
+      )
+
+      event =
+        send_and_receive(
+          [:phoenix, :live_view, :handle_event, :stop],
+          %{duration: System.convert_time_unit(5, :microsecond, :native)},
+          %{
+            uri: "/dashboard",
+            socket: %{
+              id: "phx-Hprop789",
+              view: MyApp.DashboardLive,
+              assigns: %{}
+            },
+            event: "click"
+          }
+        )
+
+      assert event["socket_id"] == "phx-Hprop789"
+    end
+
+    test "does not overwrite existing socket_id in event context" do
+      Honeybadger.EventContext.merge(%{socket_id: "existing-id"})
+
+      :telemetry.execute(
+        [:phoenix, :live_view, :mount, :start],
+        %{},
+        %{
+          socket: %{
+            id: "phx-Inew999",
+            view: MyApp.DashboardLive,
+            assigns: %{}
+          }
+        }
+      )
+
+      assert Honeybadger.EventContext.get(:socket_id) == "existing-id"
+    end
+  end
 end


### PR DESCRIPTION
Store socket_id in the EventContext via put_new during the mount :start handler so it is available on all subsequent events from the LiveView process, not just in per-event metadata.

This feature was originally added by @rabidpraxis in #652:

https://github.com/honeybadger-io/honeybadger-elixir/pull/652/changes#diff-1a42a24821e325599c711f6d888134d2e1f5b1ebba2560e68dd112833d70c0e4R64-R67