### PR TITLE
feat: support hackney 4.0

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,6 +33,10 @@ jobs:
               elixir: '1.19'
               otp: '28.3'
             lint: lint
+          - pair:
+              elixir: '1.19'
+              otp: '28.3'
+            hackney: '4'
 
     runs-on: ubuntu-22.04
 
@@ -53,6 +57,10 @@ jobs:
 
       - name: Run mix deps.get
         run: mix deps.ci
+
+      - name: Update hackney to 4.x
+        run: mix deps.update hackney
+        if: ${{ matrix.hackney == '4' }}
 
       - name: Run mix format
         run: mix format --check-formatted

--- a/lib/honeybadger/http_adapter.ex
+++ b/lib/honeybadger/http_adapter.ex
@@ -153,7 +153,7 @@ defmodule Honeybadger.HTTPAdapter do
 
     case adapter do
       Honeybadger.HTTPAdapter.Hackney ->
-        ensure_dependency_available!(:hackney, "~> 1.8", adapter)
+        ensure_dependency_available!(:hackney, "~> 1.8 or ~> 4.0", adapter)
 
       Honeybadger.HTTPAdapter.Req ->
         ensure_dependency_available!(Req, "~> 0.3", adapter)
@@ -163,7 +163,7 @@ defmodule Honeybadger.HTTPAdapter do
         Honeybadger requires an HTTP client but neither Req nor Hackney is available.
         Please add one of the following to your dependencies:
           {:req, "~> 0.3"}    # Recommended
-          {:hackney, "~> 1.8"}
+          {:hackney, "~> 1.8 or ~> 4.0"}
         """
 
       _ ->

--- a/lib/honeybadger/http_adapter/hackney.ex
+++ b/lib/honeybadger/http_adapter/hackney.ex
@@ -16,7 +16,9 @@ defmodule Honeybadger.HTTPAdapter.Hackney do
 
   @impl HTTPAdapter
   def request(method, url, body, headers, opts \\ []) do
-    opts = opts || []
+    opts =
+      (opts || [])
+      |> Keyword.put(:with_body, true)
 
     body = binary_or_empty_binary(body)
 
@@ -59,16 +61,11 @@ defmodule Honeybadger.HTTPAdapter.Hackney do
 
   defp decode(_headers, body, _opts), do: {:ok, body}
 
-  defp format_response({:ok, status_code, headers, client_ref}) do
-    {:ok, %HTTPResponse{status: status_code, headers: headers, body: body_from_ref(client_ref)}}
+  defp format_response({:ok, status_code, headers, body}) when is_binary(body) do
+    {:ok, %HTTPResponse{status: status_code, headers: headers, body: body}}
   end
 
   defp format_response({:error, error}), do: {:error, error}
-
-  defp body_from_ref(ref) do
-    apply(:hackney, :body, [ref])
-    |> elem(1)
-  end
 
   defp binary_or_empty_binary(nil), do: ""
   defp binary_or_empty_binary(str), do: str

--- a/mix.exs
+++ b/mix.exs
@@ -101,7 +101,7 @@ defmodule Honeybadger.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.1", optional: true},
+      {:hackney, "~> 1.8 or ~> 4.0", optional: true},
       {:req, "~> 0.5.0", optional: true},
       {:jason, "~> 1.0"},
       {:plug, ">= 1.0.0 and < 2.0.0", optional: true},


### PR DESCRIPTION
## Summary
- Loosens the hackney version constraint to `~> 1.8 or ~> 4.0` so apps can upgrade to `ex_aws ~> 2.7` (which requires `hackney ~> 4.0`) without version conflicts.
- Adapts `Honeybadger.HTTPAdapter.Hackney` to hackney 4.0's API: `request/5` now returns the body directly in the 4-tuple and `body/1` is no longer exported. We force `with_body: true` (no-op in 4.0, makes 1.x return the same shape) and match a binary body in `format_response/1`.
- Adds a CI matrix entry that runs the test suite against hackney 4.x so the new path stays covered.

## Test plan
- [x] `mix test` passes against hackney 1.20.1 (12 doctests + 219 tests)
- [x] `mix test` passes against hackney 4.0.0 (12 doctests + 219 tests)
- [x] CI green on the new `hackney: '4'` matrix entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)