### PR TITLE
chore(deps)!: require Elixir 1.16+ / OTP 25+

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,6 +19,9 @@ jobs:
         include:
           - pair:
               elixir: '1.16'
+              otp: '25.3'
+          - pair:
+              elixir: '1.16'
               otp: '26.0'
           - pair:
               elixir: '1.17'

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,9 +18,6 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: '1.15'
-              otp: '24.3'
-          - pair:
               elixir: '1.16'
               otp: '26.0'
           - pair:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.15'
+          elixir-version: '1.16'
           otp-version: '26'
 
       - name: Restore dependencies cache

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Elixir Plug, Logger and client for the :zap: [Honeybadger error notifier](https:
 
 ### Version Requirements
 
-- Erlang >= 24.0
-- Elixir >= 1.15
+- Erlang >= 25.0
+- Elixir >= 1.16
 - Plug >= 1.10
 - Phoenix >= 1.0 (This is an optional dependency and the version requirement applies only if you are using Phoenix)
 

--- a/lib/honeybadger/http_adapter.ex
+++ b/lib/honeybadger/http_adapter.ex
@@ -156,13 +156,13 @@ defmodule Honeybadger.HTTPAdapter do
         ensure_dependency_available!(:hackney, "~> 1.8 or ~> 4.0", adapter)
 
       Honeybadger.HTTPAdapter.Req ->
-        ensure_dependency_available!(Req, "~> 0.3", adapter)
+        ensure_dependency_available!(Req, "~> 0.6.1", adapter)
 
       nil ->
         raise """
         Honeybadger requires an HTTP client but neither Req nor Hackney is available.
         Please add one of the following to your dependencies:
-          {:req, "~> 0.3"}    # Recommended
+          {:req, "~> 0.6.1"}    # Recommended
           {:hackney, "~> 1.8 or ~> 4.0"}
         """
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Honeybadger.Mixfile do
     [
       app: :honeybadger,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.16",
       consolidate_protocols: Mix.env() != :test,
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
req 0.6 pulls in finch 0.22, whose PoolMetrics uses the {:write_concurrency, :auto} ETS option introduced in OTP 25, so the test suite can no longer boot on OTP 24.3. Drop the Elixir 1.15/OTP 24.3 CI pair and raise the declared minimum to Elixir 1.16.

* OTP 24 support ended in [May 2022](https://endoflife.date/erlang) 
* Elixir 1.15 support ended in [December 2023](https://endoflife.date/elixir)

BREAKING CHANGE: minimum supported Elixir is now 1.16 (OTP 25+).
