### PR TITLE
ci: add Elixir 1.20 to the test matrix

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -35,6 +35,9 @@ jobs:
           - pair:
               elixir: '1.20'
               otp: '28.5'
+          - pair:
+              elixir: '1.20'
+              otp: '29.0'
             lint: lint
           - pair:
               elixir: '1.20'

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,17 +32,17 @@ jobs:
           - pair:
               elixir: '1.19'
               otp: '28.3'
+            lint: lint
+          - pair:
+              elixir: '1.19'
+              otp: '28.3'
+            hackney: '4'
           - pair:
               elixir: '1.20'
               otp: '28.5'
           - pair:
               elixir: '1.20'
               otp: '29.0'
-            lint: lint
-          - pair:
-              elixir: '1.20'
-              otp: '28.5'
-            hackney: '4'
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,10 +32,13 @@ jobs:
           - pair:
               elixir: '1.19'
               otp: '28.3'
+          - pair:
+              elixir: '1.20'
+              otp: '28.5'
             lint: lint
           - pair:
-              elixir: '1.19'
-              otp: '28.3'
+              elixir: '1.20'
+              otp: '28.5'
             hackney: '4'
 
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Elixir 1.20 is out, so this adds it to the CI matrix.

- New pair: Elixir 1.20 / OTP 28.5
- New pair: Elixir 1.20 / OTP 29.0

Elixir 1.20 ships precompiled builds for OTP 27, 28 and 29; 28.5 and 29.0 are the newest of each available for `ubuntu-22.04`.

The net diff is just those two rows — `lint` and the hackney 4.x job stay on 1.19 / OTP 28.3.

### Why lint stays on 1.19

I initially moved `lint` onto 1.20, but 1.20's stricter type checker fails `mix compile --warnings-as-errors` on existing code:

- `Honeybadger.Insights.Base` injects its `extract_metadata/2` and `ignore?/1` defaults via `__before_compile__`, which *appends* them as clauses after each child module's own. On 1.20 that's flagged as redundant (absinthe, ecto, plug, tesla, live_view, finch), and `ignore?/1` folds to a literal `false`, making the `unless` branch in `handle_event_impl/4` unreachable (plug, oban, live_view, absinthe).
- `Logger.add_backend/1` is deprecated (`lib/honeybadger.ex:204`); `Honeybadger.Logger` is a `:gen_event` backend.
- Minor: unused `require Logger` (`lib/honeybadger.ex:172`), `xref: [exclude: ...]` and `preferred_cli_env` deprecations in `mix.exs`.

These are tracked separately so they get their own review. Tests themselves pass on 1.20 on both OTP 28.5 and 29.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY3BS8hCVvGJDNWADKNcLc