### PR TITLE
chore(deps)!: require Elixir 1.17+ / OTP 27+

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,12 +18,6 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: '1.16'
-              otp: '25.3'
-          - pair:
-              elixir: '1.16'
-              otp: '26.0'
-          - pair:
               elixir: '1.17'
               otp: '27.0'
           - pair:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.16'
-          otp-version: '26'
+          elixir-version: '1.17'
+          otp-version: '27'
 
       - name: Restore dependencies cache
         if: ${{ steps.release.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Elixir Plug, Logger and client for the :zap: [Honeybadger error notifier](https:
 
 ### Version Requirements
 
-- Erlang >= 25.0
-- Elixir >= 1.16
+- Erlang >= 27.0
+- Elixir >= 1.17
 - Plug >= 1.10
 - Phoenix >= 1.0 (This is an optional dependency and the version requirement applies only if you are using Phoenix)
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Honeybadger.Mixfile do
     [
       app: :honeybadger,
       version: @version,
-      elixir: "~> 1.16",
+      elixir: "~> 1.17",
       consolidate_protocols: Mix.env() != :test,
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Makes Elixir 1.17 the minimum supported version, dropping 1.16.

## Why

Elixir 1.16 stopped receiving bug fixes in June 2024 when 1.17 shipped, and its last patch release was 1.16.3 in May 2024. It survives only as the oldest of the last 5 minor branches in Elixir's security-patch window (1.16–1.20), and falls out entirely when 1.21 ships — already in development, likely late 2026.

The sharper argument is OTP. Elixir 1.16 supports **only OTP 24–26**, and all three are now end-of-life:

| OTP | EOL |
|---|---|
| 24 | May 10, 2024 |
| 25 | May 17, 2025 |
| 26 | May 26, 2026 |

Anyone still on 1.16 is necessarily running an Erlang/OTP release that receives no security patches, and they can't fix that without moving off 1.16 — it doesn't support OTP 27+.

This also unblocks the `ash` dependency stream. ash 3.31+ pattern-matches on the built-in `Duration` struct, which only exists in Elixir 1.17+, so `mix deps.compile` fails on 1.16 (see #718, #723). ash still declares `elixir: "~> 1.11"`, so this looks like an undeclared floor bump upstream rather than something that will be fixed.

## Changes

- `mix.exs` — `elixir: "~> 1.16"` → `"~> 1.17"`
- `.github/workflows/elixir.yml` — dropped the `1.16/25.3` and `1.16/26.0` matrix entries
- `.github/workflows/publish.yml` — publish job bumped from `1.16`/OTP `26` to `1.17`/OTP `27`, which would otherwise fail the version requirement on the next release
- `README.md` — documented requirements updated

## Note on the Erlang floor

README now says `Erlang >= 27.0` rather than `>= 25.0`. Elixir 1.17 does technically support OTP 25–27, but the 1.16 rows were the only jobs exercising OTP 25 and 26, so 27.0 is now the lowest version we test. Happy to soften this back to 25 if you'd rather claim the wider range.

## Verification

231 tests pass (12 doctests, 219 tests) and `mix format --check-formatted` is clean locally on Elixir 1.20.2 / OTP 28.3.1. The full matrix runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWNyo9THpeX3kKVGJiTxtr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - The minimum supported versions are now Elixir 1.17 and Erlang/OTP 27.0.
  - Elixir 1.16 is no longer included in continuous integration coverage.

- **Release Process**
  - Release builds now use Elixir 1.17 with Erlang/OTP 27.

- **Documentation**
  - Updated setup and compatibility guidance to reflect the new minimum versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->