### PR TITLE
chore: drop Logger clauses for Elixir 1.16 message shapes

### DIFF
--- a/lib/honeybadger/logger.ex
+++ b/lib/honeybadger/logger.ex
@@ -93,22 +93,12 @@ defmodule Honeybadger.Logger do
     |> Map.new()
   end
 
-  # Elixir < 1.17
-  defp extract_details([["GenServer ", _pid, _res, _stack, _last, _, _, last], _, state]) do
-    %{last_message: last, state: state}
-  end
-
-  # Elixir < 1.17
-  defp extract_details([[":gen_event handler ", name, _, _, _, _stack, _last, last], _, state]) do
-    %{name: name, last_message: last, state: state}
-  end
-
-  # Elixir >= 1.17
+  # Elixir 1.17 and 1.18. Since 1.19 these arrive flattened; see below.
   defp extract_details([["GenServer ", _pid, _res, _stack, _last, _, _, _, last], _, state]) do
     %{last_message: last, state: state}
   end
 
-  # Elixir >= 1.17
+  # Elixir 1.17 and 1.18. Since 1.19 these arrive flattened; see below.
   defp extract_details([[":gen_event handler ", name, _, _, _, _stack, _, _last, last], _, state]) do
     %{name: name, last_message: last, state: state}
   end


### PR DESCRIPTION
Follow-up cleanup to #724. **Stacked on that branch — merge #724 first**, then this retargets to `master` automatically.

## What

Elixir changed the shape of the chardata handed to logger backends in 1.17, adding an element to the GenServer and `:gen_event` crash reports. `extract_details/1` carried clauses for both the old and new shapes. With 1.17 as the floor, the 8-element clauses are unreachable, so they're removed.

The comments on the retained clauses were also misleading. `# Elixir >= 1.17` isn't right — since 1.19, chardata is flattened to a charlist before reaching backends and gets handled by the regex path further down (`extract_details/1` at the `is_list` clause). The retained structural clauses only ever run on 1.17 and 1.18, so they now say so.

## Verification

Full suite green on all three relevant versions:

| Elixir | OTP | Result |
|---|---|---|
| 1.17.3 | 26.2 | 231 passed |
| 1.18.4 | 28.3.1 | 231 passed |
| 1.20.2 | 28.3.1 | 231 passed |

Testing 1.17 and 1.18 specifically matters here: on 1.19+ the structural clauses aren't exercised at all, so a run on only a recent version would have proven nothing about this change.

Passing tests alone would be weak evidence, since the regex fallback could silently absorb a missed match. So I also confirmed the retained clauses are genuinely live by temporarily replacing the GenServer clause's return with a sentinel and checking that the suite failed on 1.17 as expected — it did, with exactly the one failure. The tests do discriminate between these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWNyo9THpeX3kKVGJiTxtr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash report handling for applications running on Elixir 1.17 and 1.18.
  * Updated GenServer and event-related error processing to ensure reports are interpreted correctly.
  * Removed outdated compatibility handling that could interfere with newer crash report formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->