### PR TITLE
chore: replace deprecated preferred_cli_env with def cli

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,6 @@ defmodule Honeybadger.Mixfile do
       aliases: aliases(),
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      preferred_cli_env: ["test.ci": :test],
 
       # Hex
       package: package(),
@@ -42,6 +41,12 @@ defmodule Honeybadger.Mixfile do
         source_url: @source_url,
         extras: ["README.md", "CHANGELOG.md"]
       ]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: ["test.ci": :test]
     ]
   end
 


### PR DESCRIPTION
Elixir deprecated setting `:preferred_cli_env` inside `project/0`. On 1.20 it warns on every Mix invocation and asks for a `cli/0` callback with `:preferred_envs` instead:

```
warning: setting :preferred_cli_env in your mix.exs "def project" is deprecated,
set it inside "def cli" instead
```

`cli/0` has existed since Elixir 1.15, so it's safe at our 1.17 floor (#724).

This matters beyond the warning: `test.ci` is the alias CI runs (`.github/workflows/elixir.yml:77`), and it shells out to the dummy app. If the alias stopped resolving to `:test`, `elixirc_paths(:dev)` would exclude `test/support` and the suite would break.

## Verification

Ran `mix test.ci` with `MIX_ENV` **unset** on both ends of the supported range, so the alias had to resolve the env on its own:

| Elixir | OTP | Main suite | Dummy app |
|---|---|---|---|
| 1.17.3 | 26.2 | 231 passed, 0 failures | 1 passed |
| 1.20.2 | 28.3.1 | 231 passed, 0 failures | 1 passed |

Deprecation warning confirmed gone on 1.20; `mix format --check-formatted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWNyo9THpeX3kKVGJiTxtr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command-line test configuration to ensure the continuous integration test task runs in the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->