### PR TITLE
chore(deps)!: require hackney 4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Elixir Plug, Logger and client for the :zap: [Honeybadger error notifier](https:
 - Elixir >= 1.17
 - Plug >= 1.10
 - Phoenix >= 1.0 (This is an optional dependency and the version requirement applies only if you are using Phoenix)
+- hackney >= 4.0 (This is an optional dependency and the version requirement applies only if you are using the hackney HTTP adapter)
 
 ### 1. Install the package
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Elixir Plug, Logger and client for the :zap: [Honeybadger error notifier](https:
 - Elixir >= 1.17
 - Plug >= 1.10
 - Phoenix >= 1.0 (This is an optional dependency and the version requirement applies only if you are using Phoenix)
-- hackney >= 4.0 (This is an optional dependency and the version requirement applies only if you are using the hackney HTTP adapter)
+- hackney >= 4.0 and < 5.0 (This is an optional dependency and the version requirement applies only if you are using the hackney HTTP adapter)
 
 ### 1. Install the package
 

--- a/lib/honeybadger/http_adapter.ex
+++ b/lib/honeybadger/http_adapter.ex
@@ -153,7 +153,7 @@ defmodule Honeybadger.HTTPAdapter do
 
     case adapter do
       Honeybadger.HTTPAdapter.Hackney ->
-        ensure_dependency_available!(:hackney, "~> 1.8 or ~> 4.0", adapter)
+        ensure_dependency_available!(:hackney, "~> 4.0", adapter)
 
       Honeybadger.HTTPAdapter.Req ->
         ensure_dependency_available!(Req, "~> 0.6.1", adapter)
@@ -163,7 +163,7 @@ defmodule Honeybadger.HTTPAdapter do
         Honeybadger requires an HTTP client but neither Req nor Hackney is available.
         Please add one of the following to your dependencies:
           {:req, "~> 0.6.1"}    # Recommended
-          {:hackney, "~> 1.8 or ~> 4.0"}
+          {:hackney, "~> 4.0"}
         """
 
       _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -106,7 +106,7 @@ defmodule Honeybadger.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.8 or ~> 4.0", optional: true},
+      {:hackney, "~> 4.0", optional: true},
       {:req, "~> 0.6.1 or ~> 0.7", optional: true},
       {:jason, "~> 1.0"},
       {:plug, ">= 1.0.0 and < 2.0.0", optional: true},


### PR DESCRIPTION
Narrows the optional hackney requirement from `"~> 1.8 or ~> 4.0"` to `"~> 4.0"`, dropping the 1.x line.

## ⚠️ Read this before merging

This carries a `BREAKING CHANGE:` footer, so **release-please will propose 1.0.0 again** — exactly as it did after #724, which needed the manual `Release-As` override in `0b73596`. Two ways to avoid a repeat:

1. Land a `release-please-config.json` with `"bump-minor-pre-major": true` **before** merging this. Release-please then computes 0.30.0 by itself, and every future breaking change bumps the minor while you're below 1.0.0. This is the last time you'd have to think about it.
2. Or merge this and do another one-off `Release-As: 0.30.0` override.

Option 1 is worth doing now — this is the second occurrence in two days.

## Why drop 1.x

**It cannot be made safe.** Every hackney 1.x release is vulnerable to `EEF-CVE-2026-47071` (HIGH) — a SOCKS5 TLS upgrade that ignores the caller-supplied timeout. The advisory affects 0.10.0 through 4.0.1 and is fixed **only in 4.0.1**. There is no patched 1.x release and there won't be one; 1.25.0, the newest, is still affected.

**It was already untested.** #730 moved the lock to 4.7.4, and the `hackney: '4'` matrix entry runs `mix deps.update hackney`, which resolves to the newest allowed version. Nothing in CI exercised 1.x any more, so `"~> 1.8"` had become a claim we no longer verified.

## Impact

Narrow. hackney is `optional: true` and **Req is the default adapter** — `Honeybadger.HTTPAdapter` prefers Req, falling back to hackney only when Req isn't loaded. This affects only applications that explicitly use the hackney adapter *and* pin hackney to 1.x; those need to move to hackney 4.0+.

Note the previous requirement had a gap: `"~> 1.8 or ~> 4.0"` never admitted 2.x or 3.x, so no one could have been on those lines via this package.

## Changes

- `mix.exs` — `{:hackney, "~> 1.8 or ~> 4.0", optional: true}` → `{:hackney, "~> 4.0", optional: true}`
- `README.md` — added hackney to Version Requirements, which previously didn't mention it

## Verification

- `mix deps.get` leaves `mix.lock` untouched — 4.7.4 already satisfies `~> 4.0`
- Full suite green: 232 tests on Elixir 1.17.3/OTP 26.2 and 1.20.2/OTP 28.3.1
- `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWNyo9THpeX3kKVGJiTxtr